### PR TITLE
added resetTopView method with animations and onComplete blocks as parameter

### DIFF
--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.h
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.h
@@ -139,6 +139,13 @@ typedef enum {
 /** Slides the top view back to the center. */
 - (void)resetTopView;
 
+/** Slides the top view back to the center.
+
+ @param animations Perform changes to properties that will be animated while top view is moved back to the center of the screen. Can be nil.
+ @param onComplete Executed after the animation is completed. Can be nil.
+ */
+- (void)resetTopViewWithAnimations:(void(^)())animations onComplete:(void(^)())complete;
+
 /** Returns true if the underLeft view is showing (even partially) */
 - (BOOL)underLeftShowing;
 

--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
@@ -265,9 +265,20 @@ NSString *const ECSlidingViewTopDidReset          = @"ECSlidingViewTopDidReset";
 
 - (void)resetTopView
 {
+  [self resetTopViewWithAnimations:nil onComplete:nil];
+}
+
+- (void)resetTopViewWithAnimations:(void(^)())animations onComplete:(void(^)())complete
+{
   [UIView animateWithDuration:0.25f animations:^{
+    if (animations) {
+      animations();
+    }
     [self updateTopViewHorizontalCenter:self.resettedCenter];
   } completion:^(BOOL finished) {
+    if (complete) {
+      complete();
+    }
     [self topViewHorizontalCenterDidChange:self.resettedCenter];
   }];
 }


### PR DESCRIPTION
If you wanted to switch from one side to the other you couldn't chain resetTopView and anchorTopViewTo. This is now possible by calling anchorTopView inside the onComplete Block of resetTopViewWithAnimations:onComplete:
