### PR TITLE
topViewSnapshot needs a new frame when setting topViewController

### DIFF
--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
@@ -114,6 +114,7 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
   _topViewController.view.layer.shadowPath = [UIBezierPath bezierPathWithRect:self.view.layer.bounds].CGPath;
   
   [self.view addSubview:_topViewController.view];
+  self.topViewSnapshot.frame = self.topView.bounds;
 }
 
 - (void)setUnderLeftViewController:(UIViewController *)theUnderLeftViewController


### PR DESCRIPTION
Reason for this addition is that the snapshot gets a zero rect if topViewController is set late in the game — in my case, after viewWillAppear is called. So I'm resetting the frame whenever topViewController is set. Fixed my use case.

Perhaps it's more appropriate to call adjustLayout instead of setting the frame directly, as the left and right viewControllers could also need updating in some scenarios which I can't fathom.
