### PR TITLE
Add property to allow configuration of the velocity threshold used to de...

### DIFF
--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.h
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.h
@@ -159,6 +159,12 @@ typedef enum {
  */
 @property (nonatomic, assign) ECResetStrategy resetStrategy;
 
+/** Returns the X-axis velocity threshold used for determining whether or not to process a pan to the left or right
+
+ By default, this is set to 100
+ */
+@property (nonatomic, assign) NSUInteger panningVelocityXThreshold;
+
 /** Returns a horizontal panning gesture for moving the top view.
  
  This is typically added to the top view or a top view's navigation bar.

--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
@@ -180,6 +180,7 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
   _panGesture          = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(updateTopViewHorizontalCenterWithRecognizer:)];
   self.resetTapGesture.enabled = NO;
   self.resetStrategy = ECTapping | ECPanning;
+  self.panningVelocityXThreshold = 100;
   
   self.topViewSnapshot = [[UIView alloc] initWithFrame:self.topView.bounds];
   [self.topViewSnapshot setAutoresizingMask:self.autoResizeToFillScreen];
@@ -272,9 +273,9 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
     CGPoint currentVelocityPoint = [recognizer velocityInView:self.view];
     CGFloat currentVelocityX     = currentVelocityPoint.x;
     
-    if ([self underLeftShowing] && currentVelocityX > 100) {
+    if ([self underLeftShowing] && currentVelocityX > self.panningVelocityXThreshold) {
       [self anchorTopViewTo:ECRight];
-    } else if ([self underRightShowing] && currentVelocityX < 100) {
+    } else if ([self underRightShowing] && currentVelocityX <= self.panningVelocityXThreshold) {
       [self anchorTopViewTo:ECLeft];
     } else {
       [self resetTopView];


### PR DESCRIPTION
...termine whether to open left/right in response to pan gesture.

We have found that, in our project, we need to set this property to zero. If left at the default of 100, there is a race condition when using the pan gesture to close an exposed under controller. When panning very slowly (e.g. abs(currentVelocityX) < 100 ) to close the left or right under controller, it was possible to cause a reset of the top view (e.g. remove under controller's views from the view hierarchy), immediately followed by an open of the under controller whose view was just removed. So, despite having a non-nil under controller, the side would be opened to a blank white screen.

Removing the 100 points/second buffer in the currentVelocityX check eliminates the race condition, but I'm sure that velocity check is there for a reason. As such, I've opted to add a property with the default value being 100, that I can set to zero in my projects to avoid the race condition described above.
