### PR TITLE
Always move VoiceOver focus to the current view

### DIFF
--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
@@ -318,6 +318,13 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
     if (complete) {
       complete();
     }
+    UIView *view = nil;
+    if (side == ECLeft) {
+      view = self.underRightView;
+    } else if (side == ECRight) {
+      view = self.underLeftView;
+    }
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, view);
     _topViewIsOffScreen = NO;
     [self addTopViewSnapshot];
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -353,6 +360,13 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
     if (complete) {
       complete();
     }
+    UIView *view = nil;
+    if (side == ECLeft) {
+      view = self.underRightView;
+    } else if (side == ECRight) {
+      view = self.underLeftView;
+    }
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, view);
     _topViewIsOffScreen = YES;
     [self addTopViewSnapshot];
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -383,6 +397,7 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
     if (complete) {
       complete();
     }
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, self.topView);
     [self topViewHorizontalCenterDidChange:self.resettedCenter];
   }];
 }


### PR DESCRIPTION
Without this, VoiceOver user has to touch-explore to get to the left and right 
views. And when top view is restored, they might end up in "nowhere" with 
VoiceOver. So post notification to VoiceOver that screen has changed so that 
it can reread it and focus the right element.

Future work can include adding a non-visible VoiceOver-only button to enable
VoiceOver users to dismiss the left and right under-views without having
to touch explore the top view's navigation bar buttons (which might even not
be present). Other option is to play with the accessibilityPerformEscape to
implement it at the right place to dismiss the left or right under-view.
