### PR TITLE
Do not check if panning past anchor unless anchorLeft/RightTopViewCenter is set

### DIFF
--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
@@ -294,7 +294,8 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
       newCenterPosition = self.resettedCenter;
     }
     
-    BOOL newCenterPositionIsOutsideAnchor = newCenterPosition < self.anchorLeftTopViewCenter || self.anchorRightTopViewCenter < newCenterPosition;
+    BOOL newCenterPositionIsOutsideAnchor = (self.anchorLeftTopViewCenter != NSNotFound && newCenterPosition < self.anchorLeftTopViewCenter) ||
+                                            (self.anchorRightTopViewCenter != NSNotFound && self.anchorRightTopViewCenter < newCenterPosition);
     
     if ((newCenterPositionIsOutsideAnchor && self.shouldAllowPanningPastAnchor) || !newCenterPositionIsOutsideAnchor) {
       [self topViewHorizontalCenterWillChange:newCenterPosition];


### PR DESCRIPTION
This fixes https://github.com/edgecase/ECSlidingViewController/issues/125 where if anchorLeftTopViewCenter returns NSNotFound (i.e. there is no underRightViewController), panning is completely disabled.
