### PR TITLE
Prevent top view resetting when dragged past anchor

### DIFF
--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
@@ -304,10 +304,12 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
   } else if (recognizer.state == UIGestureRecognizerStateEnded || recognizer.state == UIGestureRecognizerStateCancelled) {
     CGPoint currentVelocityPoint = [recognizer velocityInView:self.view];
     CGFloat currentVelocityX     = currentVelocityPoint.x;
+    BOOL viewIsPastAnchor = (self.anchorLeftTopViewCenter != NSNotFound && self.topView.layer.position.x <= self.anchorLeftTopViewCenter) ||
+    (self.anchorRightTopViewCenter != NSNotFound && self.topView.layer.position.x >= self.anchorRightTopViewCenter);
     
-    if ([self underLeftShowing] && currentVelocityX > self.panningVelocityXThreshold) {
+    if ([self underLeftShowing] && (viewIsPastAnchor || currentVelocityX > self.panningVelocityXThreshold)) {
       [self anchorTopViewTo:ECRight];
-    } else if ([self underRightShowing] && -currentVelocityX > self.panningVelocityXThreshold) {
+    } else if ([self underRightShowing] && (viewIsPastAnchor || -currentVelocityX > self.panningVelocityXThreshold)) {
       [self anchorTopViewTo:ECLeft];
     } else {
       [self resetTopView];


### PR DESCRIPTION
Maybe this could be improved by introducing another set of conditionals involving `viewIsPastAnchor` and the velocity toward reset.

With this change, it's impossible to trigger a reset based on panning if the view is at or beyond the anchor point (dragging it back over the anchor would still reset). This would only be an issue if the top view has a lot of distance between its anchor point and the point at which it goes offscreen.
