### PR TITLE
Fix compatibility with iOS <= 6.1 - adjusting screen height

### DIFF
--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
@@ -553,7 +553,12 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
 {
     CGFloat statusBarHeight = 0;
     
-    if (self.shouldAdjustChildViewHeightForStatusBar) {
+    BOOL legacyScreenHeightEnabled = NO;
+    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+        legacyScreenHeightEnabled = YES;
+    }
+    
+    if (self.shouldAdjustChildViewHeightForStatusBar || legacyScreenHeightEnabled) {
         statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
         if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
             statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.width;
@@ -569,7 +574,12 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
         bounds.size.width  = width;
     }
     
-    bounds.origin.y += statusBarHeight;
+    if (!legacyScreenHeightEnabled) {
+        // In iOS <= 6.1 the container view is already offset below the status bar.
+        // so no need to offset it if we use shouldAdjustChildViewHeightForStatusBar in iOS 7+.
+        bounds.origin.y += statusBarHeight;
+    }
+    
     bounds.size.height -= statusBarHeight;
     
     return bounds;


### PR DESCRIPTION
Hey,
The latest version 1.3.1 works really well on iOS 7.
But when running on iOS 6.1 or below , the ECSlidingViewController view height it too high, so the bottom of the child views are offscreen.
This is due to 'fullViewBounds' returns the screen bounds. So for iOS 6.1 it will reduce the status bar height.

Feel free to rename the local variable I used if you find more explainable name :)

thanks,
Nissan
