### PR TITLE
add iOS 7 native snapshot feature

### DIFF
--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.h
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.h
@@ -145,12 +145,6 @@ typedef enum {
  */
 @property (nonatomic, assign) BOOL shouldAdjustChildViewHeightForStatusBar;
 
-/** Specifies if snapshot should use native -[UIScreen snapshotViewAfterScreenUpdates:]. iOS 7 only.
-
- By default, this is set to NO
- */
-@property (nonatomic, assign) BOOL shouldUseNativeSnapshotFeature;
-
 /** Specifies the behavior for the under left width
  
  By default, this is set to ECFullWidth

--- a/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/Vendor/ECSlidingViewController/ECSlidingViewController.m
@@ -330,7 +330,7 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
 
 - (void)anchorTopViewTo:(ECSide)side animations:(void (^)())animations onComplete:(void (^)())complete
 {
-    if (self.shouldUseNativeSnapshotFeature && ([[UIDevice currentDevice].systemVersion floatValue] >= 7.0f)) {
+    if ([[UIScreen mainScreen] respondsToSelector:@selector(snapshotViewAfterScreenUpdates:)]) {
         self.topViewSnapshot = [[UIScreen mainScreen] snapshotViewAfterScreenUpdates:YES];
         [self.topViewSnapshot setAutoresizingMask:self.autoResizeToFillScreen];
         [self.topViewSnapshot addGestureRecognizer:self.resetTapGesture];
@@ -384,7 +384,7 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
 
 - (void)anchorTopViewOffScreenTo:(ECSide)side animations:(void(^)())animations onComplete:(void(^)())complete
 {
-    if (self.shouldUseNativeSnapshotFeature && ([[UIDevice currentDevice].systemVersion floatValue] >= 7.0f)) {
+    if ([[UIScreen mainScreen] respondsToSelector:@selector(snapshotViewAfterScreenUpdates:)]) {
         self.topViewSnapshot = [[UIScreen mainScreen] snapshotViewAfterScreenUpdates:YES];
         [self.topViewSnapshot setAutoresizingMask:self.autoResizeToFillScreen];
         [self.topViewSnapshot addGestureRecognizer:self.resetTapGesture];


### PR DESCRIPTION
The patch allows developer to use native iOS 7 screen snapshot feature.

It helps to utilize functionality that resembles the one MailBox app is using, when status bar is moving away along with the top view controller.
