### PR TITLE
Fixed View Size at start of zoom transition

### DIFF
--- a/Examples/TransitionFun/TransitionFun/MEZoomAnimationController.m
+++ b/Examples/TransitionFun/TransitionFun/MEZoomAnimationController.m
@@ -74,6 +74,7 @@ static CGFloat const MEZoomAnimationScaleFactor = 0.75;
     UIView *containerView = [transitionContext containerView];
     
     UIView *topView = topViewController.view;
+    topView.bounds = [UIScreen mainScreen].bounds;
     
     underLeftViewController.view.layer.transform = CATransform3DIdentity;
     


### PR DESCRIPTION
View would have the wrong height at the begining of the transition then
it would snap to the correct height. This fixed it for me.
