### PR TITLE
Explicitly declare the top, left, right controller ivars as protected

### DIFF
--- a/ECSlidingViewController/ECSlidingViewController.h
+++ b/ECSlidingViewController/ECSlidingViewController.h
@@ -110,6 +110,11 @@
     CGFloat _anchorRightRevealAmount;
     UIPanGestureRecognizer *_panGesture;
     UITapGestureRecognizer *_resetTapGesture;
+                                                           
+    @protected
+    UIViewController *_topViewController;
+    UIViewController *_underLeftViewController;
+    UIViewController *_underRightViewController;
 }
 
 

--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -66,6 +66,10 @@
 
 @implementation ECSlidingViewController
 
+@synthesize topViewController=_topViewController;
+@synthesize underLeftViewController=_underLeftViewController;
+@synthesize underRightViewController=_underRightViewController;
+
 #pragma mark - Constructors
 
 + (instancetype)slidingWithTopViewController:(UIViewController *)topViewController {


### PR DESCRIPTION
Explicitly declare the topViewController, underLeftViewController, and underRightViewController ivars as protected so a subclass of ECSlidingViewController has access.

This change was needed in order to provide a custom transition when changing the topViewController.  We need to provide an alternate way (i.e. shortcut) for our app to navigate from one top view controller to another one.  In particular, the current top view controller has a button that when tapped will transition directly to a new top controller.  If we just called the setTopViewController method then we would not have the ability to provide our own animation (e.g. cross dissolve) from the current top controller to the new one.  With this change we were able to subclass ECSlidingViewController and add the following method:

``` objc
- (void)transitionToViewController:(UIViewController *)toViewController
{
   UIViewController *oldTopViewController = _topViewController;

   [self addChildViewController:toViewController];
   [toViewController didMoveToParentViewController:self];

   toViewController.view.frame = self.topViewController.view.frame;

   if ([self isViewLoaded]) {
       [toViewController beginAppearanceTransition:YES animated:YES];
       [self.view addSubview:toViewController.view];
       [toViewController endAppearanceTransition];
   }

   [UIView transitionFromView:oldTopViewController.view
toView:toViewController.view duration:0.5
options:UIViewAnimationOptionTransitionCrossDissolve completion:^ (BOOL
finished) {
       [oldTopViewController.view removeFromSuperview];
       [oldTopViewController willMoveToParentViewController:nil];
       [oldTopViewController beginAppearanceTransition:NO animated:YES];
       [oldTopViewController removeFromParentViewController];
       [oldTopViewController endAppearanceTransition];
       _topViewController = toViewController;
   }];
}
```
