### PR TITLE
Fix unwind segues

### DIFF
--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -741,7 +741,7 @@
     if (recognizer.state == UIGestureRecognizerStateBegan) {
         _isInteractive = YES;
     }
-    
+    [self.view endEditing:YES];
     [self.defaultInteractiveTransition updateTopViewHorizontalCenterWithRecognizer:recognizer];
     _isInteractive = NO;
 }


### PR DESCRIPTION
If a modal vc is presented over a sliding view controller then when the modal vc is dismissed the unwind segue returned is a custom segue that doesn’t know how to handle dismissing a modal vc. In this case super should be called if under left or right isn’t the destination.
