### PR TITLE
Fix unwind segues that don’t have to do with anchoring

### DIFF
--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -200,6 +200,9 @@
 }
 
 - (UIStoryboardSegue *)segueForUnwindingToViewController:(UIViewController *)toViewController fromViewController:(UIViewController *)fromViewController identifier:(NSString *)identifier {
+    if (!([self.underLeftViewController isMemberOfClass:[toViewController class]] || [self.underRightViewController isMemberOfClass:[toViewController class]])) {
+        return [super segueForUnwindingToViewController:toViewController fromViewController:fromViewController identifier:identifier];
+    }
     ECSlidingSegue *unwindSegue = [[ECSlidingSegue alloc] initWithIdentifier:identifier source:fromViewController destination:toViewController];
     [unwindSegue setValue:@YES forKey:@"isUnwinding"];
     return unwindSegue;


### PR DESCRIPTION
If a modal vc is presented over a sliding view controller then when the modal vc is dismissed the unwind segue returned is a custom segue that doesn’t know how to handle dismissing a modal vc. In this case super should be called if under left or right isn’t the destination.

Sorry for the last PR, accidentally added an unnecessary commit.
