### PR TITLE
the view is done editing when a pan gesture is started or menu button is...

### DIFF
--- a/ECSlidingViewController.podspec
+++ b/ECSlidingViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ECSlidingViewController"
-  s.version      = "2.0.1"
+  s.version      = "2.0.2"
   s.summary      = "View controller container that presents its child view controllers in two sliding layers. Inspired by the Path 2.0 and Facebook iPhone apps."
   s.description  = "ECSlidingViewController is a view controller container that presents its child view controllers in two layers. It provides functionality for sliding the top view to reveal the views underneath it. This functionality is inspired by the Path 2.0 and Facebook iPhone apps."
   s.homepage     = "https://github.com/ECSlidingViewController/ECSlidingViewController"

--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -420,27 +420,26 @@
 }
 
 - (void)anchorTopViewToRightAnimated:(BOOL)animated onComplete:(void (^)())complete {
-    self.isAnimated = animated;
-    self.animationComplete = complete;
-    ECSlidingViewControllerOperation operation = [self operationFromPosition:self.currentTopViewPosition toPosition:ECSlidingViewControllerTopViewPositionAnchoredRight];
-    [self animateOperation:operation];
+    [self resetViewAnimated:animated toPosition:ECSlidingViewControllerTopViewPositionAnchoredRight onComplete:complete];
 }
 
 - (void)anchorTopViewToLeftAnimated:(BOOL)animated onComplete:(void (^)())complete {
-    self.isAnimated = animated;
-    self.animationComplete = complete;
-    ECSlidingViewControllerOperation operation = [self operationFromPosition:self.currentTopViewPosition toPosition:ECSlidingViewControllerTopViewPositionAnchoredLeft];
-    [self animateOperation:operation];
+    [self resetViewAnimated:animated toPosition:ECSlidingViewControllerTopViewPositionAnchoredLeft onComplete:complete];
 }
 
 - (void)resetTopViewAnimated:(BOOL)animated onComplete:(void(^)())complete {
-    self.isAnimated = animated;
-    self.animationComplete = complete;
-    ECSlidingViewControllerOperation operation = [self operationFromPosition:self.currentTopViewPosition toPosition:ECSlidingViewControllerTopViewPositionCentered];
-    [self animateOperation:operation];
+    [self resetViewAnimated:animated toPosition:ECSlidingViewControllerTopViewPositionCentered onComplete:complete];
 }
 
 #pragma mark - Private
+
+- (void)resetViewAnimated:(BOOL)animated toPosition:(ECSlidingViewControllerTopViewPosition)position onComplete:(void(^)())complete {
+    self.isAnimated = animated;
+    self.animationComplete = complete;
+    [self.view endEditing:YES];
+    ECSlidingViewControllerOperation operation = [self operationFromPosition:self.currentTopViewPosition toPosition:position];
+    [self animateOperation:operation];
+}
 
 - (CGRect)topViewCalculatedFrameForPosition:(ECSlidingViewControllerTopViewPosition)position {
     CGRect frameFromDelegate = [self frameFromDelegateForViewController:self.topViewController
@@ -736,6 +735,7 @@
 
 - (void)detectPanGestureRecognizer:(UIPanGestureRecognizer *)recognizer {
     if (recognizer.state == UIGestureRecognizerStateBegan) {
+        [self.view endEditing:YES];
         _isInteractive = YES;
     }
     


### PR DESCRIPTION
... tapped, so keyboard is resigned if it is currently active on the view, slight refactoring

When there is a keyboard on a view controller (on a form, for example), and a menu is activated, currently the keyboard stays up when the menu is displayed. I added [self.view endEditing:YES] when a pan gesture or menu button is activated, so the keyboard is resigned. Also, did some slight refactoring. 
