### PR TITLE
Reverted "pangesturerecognizer action dispkatch async" commit 

### DIFF
--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -747,9 +747,8 @@
         [self.view endEditing:YES];
         _isInteractive = YES;
     }
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.defaultInteractiveTransition updateTopViewHorizontalCenterWithRecognizer:recognizer];
-    });
+    
+    [self.defaultInteractiveTransition updateTopViewHorizontalCenterWithRecognizer:recognizer];
     _isInteractive = NO;
 }
 


### PR DESCRIPTION
When the pan gesture is detected the transition happens immediately. Therefore the user cannot hold and swipe the top view controller.
If this is a new feature let me know and I can implement a property for turning off this functionality.
