### PR TITLE
Call completion block even when no animation occurs

### DIFF
--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -573,7 +573,8 @@
 - (void)animateOperation:(ECSlidingViewControllerOperation)operation {
     if (![self operationIsValid:operation]){
         _isInteractive = NO;
-        if (operation == ECSlidingViewControllerOperationNone) self.animationComplete();
+        if (operation == ECSlidingViewControllerOperationNone && self.animationComplete) self.animationComplete();
+        self.animationComplete = nil;
         return;
     }
     if (self.transitionInProgress) return;


### PR DESCRIPTION
The method itself is idempotent, so I think it should call the completion block even if no state change occurs.
