### PR TITLE
Missing  targetTransform (UIViewControllerTransitionCoordinatorContext r...

### DIFF
--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -783,6 +783,16 @@
 
 #pragma mark - UIViewControllerContextTransitioning and UIViewControllerTransitionCoordinatorContext
 
+- (CGAffineTransform)targetTransform{
+    // This transform is the identity transform when no rotation is applied;
+    return CGAffineTransformIdentity;
+}
+
+- (UIView *)viewForKey:(NSString *)key{
+    /*The view returned by this method may or may not be the root view of the corresponding view controller. A situation where the views may not be the same is when a system-provided presentation controller installs another view underneath the presented view controller’s view.*/
+    return nil;
+}
+
 - (UIView *)containerView {
     return self.view;
 }


### PR DESCRIPTION
targetTransform (UIViewControllerTransitionCoordinatorContext required) and viewForKey (UIViewControllerContextTransitioning required) causing warnings when importing ECSlidingViewController Folder to any project.