### PR TITLE
Add support for Carthage and Swift

### DIFF
--- a/Examples.xcworkspace/contents.xcworkspacedata
+++ b/Examples.xcworkspace/contents.xcworkspacedata
@@ -1,1 +1,19 @@
-<?xml version='1.0' encoding='UTF-8'?><Workspace version='1.0'><FileRef location='group:Examples/BasicMenu/BasicMenu.xcodeproj'/><FileRef location='group:Examples/LayoutDemo/LayoutDemo.xcodeproj'/><FileRef location='group:Examples/TransitionFun/TransitionFun.xcodeproj'/><FileRef location='group:Examples/Pods/Pods.xcodeproj'/></Workspace>
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Examples/Carthage/ECSlidingViewController.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Examples/BasicMenu/BasicMenu.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Examples/LayoutDemo/LayoutDemo.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Examples/TransitionFun/TransitionFun.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Examples/Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/Carthage/ECSlidingViewController.xcodeproj/project.pbxproj
+++ b/Examples/Carthage/ECSlidingViewController.xcodeproj/project.pbxproj
@@ -1,0 +1,345 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		364C5FBB1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 364C5FAE1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		364C5FBC1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 364C5FAF1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.m */; };
+		364C5FBD1B1C988E0092C85D /* ECSlidingAnimationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 364C5FB01B1C988E0092C85D /* ECSlidingAnimationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		364C5FBE1B1C988E0092C85D /* ECSlidingAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 364C5FB11B1C988E0092C85D /* ECSlidingAnimationController.m */; };
+		364C5FBF1B1C988E0092C85D /* ECSlidingConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 364C5FB21B1C988E0092C85D /* ECSlidingConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		364C5FC01B1C988E0092C85D /* ECSlidingInteractiveTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 364C5FB31B1C988E0092C85D /* ECSlidingInteractiveTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		364C5FC11B1C988E0092C85D /* ECSlidingInteractiveTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 364C5FB41B1C988E0092C85D /* ECSlidingInteractiveTransition.m */; };
+		364C5FC21B1C988E0092C85D /* ECSlidingSegue.h in Headers */ = {isa = PBXBuildFile; fileRef = 364C5FB51B1C988E0092C85D /* ECSlidingSegue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		364C5FC31B1C988E0092C85D /* ECSlidingSegue.m in Sources */ = {isa = PBXBuildFile; fileRef = 364C5FB61B1C988E0092C85D /* ECSlidingSegue.m */; };
+		364C5FC41B1C988E0092C85D /* ECSlidingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 364C5FB71B1C988E0092C85D /* ECSlidingViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		364C5FC51B1C988E0092C85D /* ECSlidingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 364C5FB81B1C988E0092C85D /* ECSlidingViewController.m */; };
+		364C5FC61B1C988E0092C85D /* UIViewController+ECSlidingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 364C5FB91B1C988E0092C85D /* UIViewController+ECSlidingViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		364C5FC71B1C988E0092C85D /* UIViewController+ECSlidingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 364C5FBA1B1C988E0092C85D /* UIViewController+ECSlidingViewController.m */; };
+		364D86CD1B1C8D52006B8C97 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 364D86CC1B1C8D52006B8C97 /* Info.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		361BE0681B1C8D15004EEB1A /* ECSlidingViewController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ECSlidingViewController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		364C5FAE1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ECPercentDrivenInteractiveTransition.h; sourceTree = "<group>"; };
+		364C5FAF1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ECPercentDrivenInteractiveTransition.m; sourceTree = "<group>"; };
+		364C5FB01B1C988E0092C85D /* ECSlidingAnimationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ECSlidingAnimationController.h; sourceTree = "<group>"; };
+		364C5FB11B1C988E0092C85D /* ECSlidingAnimationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ECSlidingAnimationController.m; sourceTree = "<group>"; };
+		364C5FB21B1C988E0092C85D /* ECSlidingConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ECSlidingConstants.h; sourceTree = "<group>"; };
+		364C5FB31B1C988E0092C85D /* ECSlidingInteractiveTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ECSlidingInteractiveTransition.h; sourceTree = "<group>"; };
+		364C5FB41B1C988E0092C85D /* ECSlidingInteractiveTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ECSlidingInteractiveTransition.m; sourceTree = "<group>"; };
+		364C5FB51B1C988E0092C85D /* ECSlidingSegue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ECSlidingSegue.h; sourceTree = "<group>"; };
+		364C5FB61B1C988E0092C85D /* ECSlidingSegue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ECSlidingSegue.m; sourceTree = "<group>"; };
+		364C5FB71B1C988E0092C85D /* ECSlidingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ECSlidingViewController.h; sourceTree = "<group>"; };
+		364C5FB81B1C988E0092C85D /* ECSlidingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ECSlidingViewController.m; sourceTree = "<group>"; };
+		364C5FB91B1C988E0092C85D /* UIViewController+ECSlidingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+ECSlidingViewController.h"; sourceTree = "<group>"; };
+		364C5FBA1B1C988E0092C85D /* UIViewController+ECSlidingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+ECSlidingViewController.m"; sourceTree = "<group>"; };
+		364D86CC1B1C8D52006B8C97 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		361BE0641B1C8D15004EEB1A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		361BE05E1B1C8D15004EEB1A = {
+			isa = PBXGroup;
+			children = (
+				364C5FAD1B1C988E0092C85D /* ECSlidingViewController */,
+				361BE06B1B1C8D15004EEB1A /* Supporting Files */,
+				361BE0691B1C8D15004EEB1A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		361BE0691B1C8D15004EEB1A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				361BE0681B1C8D15004EEB1A /* ECSlidingViewController.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		361BE06B1B1C8D15004EEB1A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				364D86CC1B1C8D52006B8C97 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			path = ECSlidingViewController;
+			sourceTree = "<group>";
+		};
+		364C5FAD1B1C988E0092C85D /* ECSlidingViewController */ = {
+			isa = PBXGroup;
+			children = (
+				364C5FAE1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.h */,
+				364C5FAF1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.m */,
+				364C5FB01B1C988E0092C85D /* ECSlidingAnimationController.h */,
+				364C5FB11B1C988E0092C85D /* ECSlidingAnimationController.m */,
+				364C5FB21B1C988E0092C85D /* ECSlidingConstants.h */,
+				364C5FB31B1C988E0092C85D /* ECSlidingInteractiveTransition.h */,
+				364C5FB41B1C988E0092C85D /* ECSlidingInteractiveTransition.m */,
+				364C5FB51B1C988E0092C85D /* ECSlidingSegue.h */,
+				364C5FB61B1C988E0092C85D /* ECSlidingSegue.m */,
+				364C5FB71B1C988E0092C85D /* ECSlidingViewController.h */,
+				364C5FB81B1C988E0092C85D /* ECSlidingViewController.m */,
+				364C5FB91B1C988E0092C85D /* UIViewController+ECSlidingViewController.h */,
+				364C5FBA1B1C988E0092C85D /* UIViewController+ECSlidingViewController.m */,
+			);
+			name = ECSlidingViewController;
+			path = ../../ECSlidingViewController;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		361BE0651B1C8D15004EEB1A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				364C5FC21B1C988E0092C85D /* ECSlidingSegue.h in Headers */,
+				364C5FC61B1C988E0092C85D /* UIViewController+ECSlidingViewController.h in Headers */,
+				364C5FBD1B1C988E0092C85D /* ECSlidingAnimationController.h in Headers */,
+				364C5FC41B1C988E0092C85D /* ECSlidingViewController.h in Headers */,
+				364C5FBB1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.h in Headers */,
+				364C5FC01B1C988E0092C85D /* ECSlidingInteractiveTransition.h in Headers */,
+				364C5FBF1B1C988E0092C85D /* ECSlidingConstants.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		361BE0671B1C8D15004EEB1A /* ECSlidingViewController */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 361BE07E1B1C8D15004EEB1A /* Build configuration list for PBXNativeTarget "ECSlidingViewController" */;
+			buildPhases = (
+				361BE0631B1C8D15004EEB1A /* Sources */,
+				361BE0641B1C8D15004EEB1A /* Frameworks */,
+				361BE0651B1C8D15004EEB1A /* Headers */,
+				361BE0661B1C8D15004EEB1A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ECSlidingViewController;
+			productName = ECSlidingViewController;
+			productReference = 361BE0681B1C8D15004EEB1A /* ECSlidingViewController.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		361BE05F1B1C8D15004EEB1A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				ORGANIZATIONNAME = me;
+				TargetAttributes = {
+					361BE0671B1C8D15004EEB1A = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+				};
+			};
+			buildConfigurationList = 361BE0621B1C8D15004EEB1A /* Build configuration list for PBXProject "ECSlidingViewController" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 361BE05E1B1C8D15004EEB1A;
+			productRefGroup = 361BE0691B1C8D15004EEB1A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				361BE0671B1C8D15004EEB1A /* ECSlidingViewController */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		361BE0661B1C8D15004EEB1A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				364D86CD1B1C8D52006B8C97 /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		361BE0631B1C8D15004EEB1A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				364C5FBC1B1C988E0092C85D /* ECPercentDrivenInteractiveTransition.m in Sources */,
+				364C5FC51B1C988E0092C85D /* ECSlidingViewController.m in Sources */,
+				364C5FBE1B1C988E0092C85D /* ECSlidingAnimationController.m in Sources */,
+				364C5FC31B1C988E0092C85D /* ECSlidingSegue.m in Sources */,
+				364C5FC71B1C988E0092C85D /* UIViewController+ECSlidingViewController.m in Sources */,
+				364C5FC11B1C988E0092C85D /* ECSlidingInteractiveTransition.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		361BE07C1B1C8D15004EEB1A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		361BE07D1B1C8D15004EEB1A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		361BE07F1B1C8D15004EEB1A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		361BE0801B1C8D15004EEB1A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		361BE0621B1C8D15004EEB1A /* Build configuration list for PBXProject "ECSlidingViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				361BE07C1B1C8D15004EEB1A /* Debug */,
+				361BE07D1B1C8D15004EEB1A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		361BE07E1B1C8D15004EEB1A /* Build configuration list for PBXNativeTarget "ECSlidingViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				361BE07F1B1C8D15004EEB1A /* Debug */,
+				361BE0801B1C8D15004EEB1A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 361BE05F1B1C8D15004EEB1A /* Project object */;
+}

--- a/Examples/Carthage/ECSlidingViewController.xcodeproj/xcshareddata/xcschemes/ECSlidingViewController.xcscheme
+++ b/Examples/Carthage/ECSlidingViewController.xcodeproj/xcshareddata/xcschemes/ECSlidingViewController.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "361BE0671B1C8D15004EEB1A"
+               BuildableName = "ECSlidingViewController.framework"
+               BlueprintName = "ECSlidingViewController"
+               ReferencedContainer = "container:ECSlidingViewController.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "361BE0721B1C8D15004EEB1A"
+               BuildableName = "ECSlidingViewControllerTests.xctest"
+               BlueprintName = "ECSlidingViewControllerTests"
+               ReferencedContainer = "container:ECSlidingViewController.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "361BE0721B1C8D15004EEB1A"
+               BuildableName = "ECSlidingViewControllerTests.xctest"
+               BlueprintName = "ECSlidingViewControllerTests"
+               ReferencedContainer = "container:ECSlidingViewController.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "361BE0671B1C8D15004EEB1A"
+            BuildableName = "ECSlidingViewController.framework"
+            BlueprintName = "ECSlidingViewController"
+            ReferencedContainer = "container:ECSlidingViewController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "361BE0671B1C8D15004EEB1A"
+            BuildableName = "ECSlidingViewController.framework"
+            BlueprintName = "ECSlidingViewController"
+            ReferencedContainer = "container:ECSlidingViewController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "361BE0671B1C8D15004EEB1A"
+            BuildableName = "ECSlidingViewController.framework"
+            BlueprintName = "ECSlidingViewController"
+            ReferencedContainer = "container:ECSlidingViewController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/Carthage/Info.plist
+++ b/Examples/Carthage/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>me.enriquez.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Examples/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,2718 +1,1094 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>015F32CA0DA741C5A9A828AD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05A0F7FF4A2241F7A02A4271</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>05A0F7FF4A2241F7A02A4271</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ECSlidingAnimationController.m</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECSlidingAnimationController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05EF9BE4EEEB466A811E8459</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>D60A817B0221416EA841BD1A</string>
-				<string>41BDD827DA074B90B26D375E</string>
-				<string>248080785E4C400DAD6F9FB4</string>
-				<string>B07A32185B4F45128B3A6AFB</string>
-				<string>4B1987B65C934009B52945DB</string>
-				<string>A97C1315365F47D8B3380319</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>07CE8AF7EA58464F9EA164A7</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E0F2931EE55E4D03A0739B66</string>
-				<string>015F32CA0DA741C5A9A828AD</string>
-				<string>8062C39962DF4F8AB06BAF08</string>
-				<string>AB342813E2F74E4F835EBBA6</string>
-				<string>9A1E6AFC820D4912B9A8B1D7</string>
-				<string>A09BA4C6E28E4ADABE9279FA</string>
-				<string>C07E928F6BEB44419835424C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>092C56D382964781A8ABC9AA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ECPercentDrivenInteractiveTransition.m</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECPercentDrivenInteractiveTransition.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0933D46FF1B74BB8B59E866A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>5AA59CFDD592431CBEC30776</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>09E7FA1FCEA1434083E1225F</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>54BF60C37764452F917688A3</string>
-			<key>buildPhases</key>
-			<array>
-				<string>B887D914A4244D338E66F948</string>
-				<string>E5A77ABDAF994AE98EAE2749</string>
-				<string>B2E7F946B62347D5BAFC196F</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-LayoutDemo-ECSlidingViewController</string>
-			<key>productName</key>
-			<string>Pods-LayoutDemo-ECSlidingViewController</string>
-			<key>productReference</key>
-			<string>B07A32185B4F45128B3A6AFB</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>0B0AB1A3798A4843AD2B24B0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ECSlidingSegue.m</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECSlidingSegue.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0D4CC7DADC504DC488F26F47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F0B235E9AE644CF5BA0DECE0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>115D0AA1FEE44ED9BFA6FDC6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ECSlidingSegue.h</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECSlidingSegue.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>19E8FD9227954EBABC12B848</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-ECSlidingViewController-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1A5858B704E146E3B61E1499</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4488690758604C8F9D6A860A</string>
-				<string>2690AD410CC44AFB98D42F6D</string>
-				<string>3CFAA80265F94F81AB01E346</string>
-				<string>B54CDABD6F3949B4852991AB</string>
-				<string>C681802AD9D743E3B2F15288</string>
-				<string>B351D5B91ACD44409F2B731C</string>
-				<string>9D8455543EF84ED6B1C64E1A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>1AEEC0B2CCCB41508CDEDB8B</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>27EBABFA6F64419287E70912</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>5607EBE399554D25A42963E6</string>
-			<key>remoteInfo</key>
-			<string>Pods-TransitionFun-ECSlidingViewController</string>
-		</dict>
-		<key>1E57B5648C1D4537AE30F5B9</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>09E7FA1FCEA1434083E1225F</string>
-			<key>targetProxy</key>
-			<string>F1533D22221348B9A957F2E2</string>
-		</dict>
-		<key>1ECDC9401E6B479996E25C18</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>711813210CAA4293BE836D01</string>
-				<string>700EDB93E66E4C9D99C2B664</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>238EA7D177EB4FAB9D5A3655</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7890A641D03E4EE9BB98FEB3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>248080785E4C400DAD6F9FB4</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-LayoutDemo.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>266FD155A6CE49BBA20886BC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-TransitionFun-ECSlidingViewController.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2690AD410CC44AFB98D42F6D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D79299614C764BFBB7F0C1EC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>27EBABFA6F64419287E70912</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0500</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>D8F6F0FAED3F4CCFBFF0D670</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>8CF9B69AA66E4C74A9B70153</string>
-			<key>productRefGroup</key>
-			<string>05EF9BE4EEEB466A811E8459</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>3E89CAB1367F47378AAF44F7</string>
-				<string>D9FA22B238864DA6A7847C15</string>
-				<string>4261EB551A7D4ABDAA4189E5</string>
-				<string>09E7FA1FCEA1434083E1225F</string>
-				<string>C99F1FA8CC2B4795B19221E3</string>
-				<string>5607EBE399554D25A42963E6</string>
-			</array>
-		</dict>
-		<key>28382F8BADDE4979854C1FA8</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4859D347BD254042A7AC6B5B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>29207289750D4283A9F23981</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5609A3734828446587B61150</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2DBA62E97F7949FD8F936655</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2ED0AC593A9F4F839E88DA99</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2DC9E5F6F94C4A55B633C130</key>
-		<dict>
-			<key>fileRef</key>
-			<string>80F36B3763C44569BB95B091</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ED0AC593A9F4F839E88DA99</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo-ECSlidingViewController-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>32419C2864D54AA5AFC09305</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo-ECSlidingViewController-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>34FD29AEFB7943B1BE03B53B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05A0F7FF4A2241F7A02A4271</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>3613B000FCB149E1B702C04F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-TransitionFun-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>37E2707459334890AB714C1E</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>48543482890F4F2DA34C3AEC</string>
-				<string>550F6B23D30B4797837A9E0E</string>
-				<string>C2F15A24398944BC9587F236</string>
-				<string>9BC56AF1A83E491FBEA8A8C4</string>
-				<string>A389F37400B4492BA568CAFF</string>
-				<string>A1BF772005AF4B5AAEC8CB72</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-LayoutDemo</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>37F38BB4AB6048D68206A017</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3E3ABBA487184781AF292992</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Pods-TransitionFun-ECSlidingViewController-prefix.pch</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>38F7F851D6EA47C9AC4682D3</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>5B42A92F4B5042399BA84719</string>
-				<string>C71497570ABC4133A4074557</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>3BB7AB75322C440AB6E0AA60</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>32419C2864D54AA5AFC09305</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Pods-LayoutDemo-ECSlidingViewController-prefix.pch</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>3CFAA80265F94F81AB01E346</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BA68FB4C3BA7447F9B2138B5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3E3ABBA487184781AF292992</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-TransitionFun-ECSlidingViewController-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3E89CAB1367F47378AAF44F7</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>1ECDC9401E6B479996E25C18</string>
-			<key>buildPhases</key>
-			<array>
-				<string>789C5D6385DD40CDB3B87BC3</string>
-				<string>94F96492953741C498340C79</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>CFAC7275820D48EEA2B422A7</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>productName</key>
-			<string>Pods</string>
-			<key>productReference</key>
-			<string>D60A817B0221416EA841BD1A</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>3EDD22542556494A97D25B28</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-TransitionFun.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>41BDD827DA074B90B26D375E</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-ECSlidingViewController.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>4261EB551A7D4ABDAA4189E5</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>38F7F851D6EA47C9AC4682D3</string>
-			<key>buildPhases</key>
-			<array>
-				<string>0933D46FF1B74BB8B59E866A</string>
-				<string>6ED900087B8543EA9DD230A6</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>1E57B5648C1D4537AE30F5B9</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-LayoutDemo</string>
-			<key>productName</key>
-			<string>Pods-LayoutDemo</string>
-			<key>productReference</key>
-			<string>248080785E4C400DAD6F9FB4</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>42FCA23101EA44F490E013A9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D79299614C764BFBB7F0C1EC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4488690758604C8F9D6A860A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5609A3734828446587B61150</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>475248BE5E1948EE8019586F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>80F36B3763C44569BB95B091</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>47EE943DCA33428BA643D147</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BED8A47BA621475397D0ABF3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>48543482890F4F2DA34C3AEC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4859D347BD254042A7AC6B5B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E723638EC04E4B9B8467E891</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4951697730A14BE2BCB4F678</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BCAE4F0F8B2A4D41B91193B4</string>
-				<string>B5C86278C531420D846D42E7</string>
-				<string>FEC80DF6B0F447B594AB0D12</string>
-				<string>B7A8EA957A1C47B6B3EA45FF</string>
-				<string>95241B9E4D4C4E33BB2892F8</string>
-				<string>AB438B83D5F34AE7B640D135</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4999A34AA9714C869560F01B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-TransitionFun-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4B1987B65C934009B52945DB</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-TransitionFun.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>4B3AC5F143944B00963BD519</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B7A8EA957A1C47B6B3EA45FF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>54BF60C37764452F917688A3</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>DD443187B28247CCB02A8769</string>
-				<string>3BB7AB75322C440AB6E0AA60</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>550F6B23D30B4797837A9E0E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5607EBE399554D25A42963E6</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>9816D1A9150243E286D958CF</string>
-			<key>buildPhases</key>
-			<array>
-				<string>07CE8AF7EA58464F9EA164A7</string>
-				<string>C580AC6BDEE942389D258D78</string>
-				<string>6A42AACD2EC94668801FB31E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-TransitionFun-ECSlidingViewController</string>
-			<key>productName</key>
-			<string>Pods-TransitionFun-ECSlidingViewController</string>
-			<key>productReference</key>
-			<string>A97C1315365F47D8B3380319</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>5609A3734828446587B61150</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ECPercentDrivenInteractiveTransition.h</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECPercentDrivenInteractiveTransition.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>56A09442694D4E11AF49C1E6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>092C56D382964781A8ABC9AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>56E90D028802477C83BE004A</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>27EBABFA6F64419287E70912</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>D9FA22B238864DA6A7847C15</string>
-			<key>remoteInfo</key>
-			<string>Pods-ECSlidingViewController</string>
-		</dict>
-		<key>572562B7BC6C4BDFBBB2E183</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BED8A47BA621475397D0ABF3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>57D37F12247C4AB882F52DAC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8D71EAADEA5445D7AA5C9EF3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>5827661A488E45BCB9B54E86</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8D71EAADEA5445D7AA5C9EF3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>5A87D753CBB74F5FA9566F9F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>41BDD827DA074B90B26D375E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5AA59CFDD592431CBEC30776</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9BC56AF1A83E491FBEA8A8C4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5B42A92F4B5042399BA84719</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>48543482890F4F2DA34C3AEC</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>6260FB9E7C8E4AE68D17E69A</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3E3ABBA487184781AF292992</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Pods-TransitionFun-ECSlidingViewController-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>64DFE6AD7E914D8FA47E5D2D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-ECSlidingViewController.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>65720D0358A3424BA412E35C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-TransitionFun-ECSlidingViewController-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68DBADCFD3D144649C7615F6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0B0AB1A3798A4843AD2B24B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>6A42AACD2EC94668801FB31E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>FF937A6AC8504307B44B38FB</string>
-				<string>7E09B382BB1544C8A47C2786</string>
-				<string>9FB763A7DCA749F7B5FAFCB1</string>
-				<string>DA82464732184EF6AD51F3B8</string>
-				<string>C182ACE7C3714049A2882E36</string>
-				<string>D6527E0BF259411397E9DFB5</string>
-				<string>F7B56F87F9A049AB8AA237D2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>6ABFE2B48C6345C0987E3FEA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>80F36B3763C44569BB95B091</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6C108F465DFF4293B3147B36</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>5607EBE399554D25A42963E6</string>
-			<key>targetProxy</key>
-			<string>1AEEC0B2CCCB41508CDEDB8B</string>
-		</dict>
-		<key>6C57ADD1986E4FFCB085FFB0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-ECSlidingViewController-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6ED900087B8543EA9DD230A6</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>6ABFE2B48C6345C0987E3FEA</string>
-				<string>D5CDB861922346179DC71211</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>700EDB93E66E4C9D99C2B664</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>BCAE4F0F8B2A4D41B91193B4</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>703CA9CBB23A4C49804E64FA</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>C0C2F6850286448584E13089</string>
-				<string>C244A4563C54447D9914C8BB</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>711813210CAA4293BE836D01</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>BCAE4F0F8B2A4D41B91193B4</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>743DBAF02BE84D44B6DE4902</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo-ECSlidingViewController.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7877BA8020AF4533AB701BCD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-TransitionFun-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7886CF6558BE4FE386740D23</key>
-		<dict>
-			<key>fileRef</key>
-			<string>80F36B3763C44569BB95B091</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7890A641D03E4EE9BB98FEB3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ECSlidingViewController.h</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECSlidingViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>789C5D6385DD40CDB3B87BC3</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4B3AC5F143944B00963BD519</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>791A2DEEE38E427598328B33</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>8108F55519FC448CB5E779DF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Development Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7969D9DA48FE427482D1D4ED</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>Podfile</string>
-			<key>path</key>
-			<string>../Podfile</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.ruby</string>
-		</dict>
-		<key>7CA7854C66D24D94A76200A3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-TransitionFun-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7D38E6427062414FACAF28F3</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>DBE0DD43F5374183862F9140</string>
-				<string>C43D89FFA2DE435A9EC21AC1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>7E09B382BB1544C8A47C2786</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D79299614C764BFBB7F0C1EC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8062C39962DF4F8AB06BAF08</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BED8A47BA621475397D0ABF3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>80F36B3763C44569BB95B091</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk/System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>8108F55519FC448CB5E779DF</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>5609A3734828446587B61150</string>
-				<string>092C56D382964781A8ABC9AA</string>
-				<string>D79299614C764BFBB7F0C1EC</string>
-				<string>05A0F7FF4A2241F7A02A4271</string>
-				<string>BA68FB4C3BA7447F9B2138B5</string>
-				<string>D6A329D2267347BBB7E44683</string>
-				<string>BED8A47BA621475397D0ABF3</string>
-				<string>115D0AA1FEE44ED9BFA6FDC6</string>
-				<string>0B0AB1A3798A4843AD2B24B0</string>
-				<string>7890A641D03E4EE9BB98FEB3</string>
-				<string>F0B235E9AE644CF5BA0DECE0</string>
-				<string>F3CE12A4DC56427EBA1ACBBB</string>
-				<string>8D71EAADEA5445D7AA5C9EF3</string>
-				<string>E6993C7BB61445CB8A6E6B87</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ECSlidingViewController</string>
-			<key>path</key>
-			<string>../..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8CF9B69AA66E4C74A9B70153</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>7969D9DA48FE427482D1D4ED</string>
-				<string>791A2DEEE38E427598328B33</string>
-				<string>B863FA83F63B4E8AB18715E4</string>
-				<string>05EF9BE4EEEB466A811E8459</string>
-				<string>FC818F6A10484B7B9502766C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8D71EAADEA5445D7AA5C9EF3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>UIViewController+ECSlidingViewController.m</string>
-			<key>path</key>
-			<string>ECSlidingViewController/UIViewController+ECSlidingViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8F972BB5274D476AA76C9A24</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-ECSlidingViewController-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>94F96492953741C498340C79</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>CDEA5973F2D5464081CC5483</string>
-				<string>5A87D753CBB74F5FA9566F9F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>951E66269A724D598B1A39F9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-TransitionFun-ECSlidingViewController-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>95241B9E4D4C4E33BB2892F8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9816D1A9150243E286D958CF</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>6260FB9E7C8E4AE68D17E69A</string>
-				<string>37F38BB4AB6048D68206A017</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>9A1E6AFC820D4912B9A8B1D7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F0B235E9AE644CF5BA0DECE0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>9BC56AF1A83E491FBEA8A8C4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9D8455543EF84ED6B1C64E1A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F3CE12A4DC56427EBA1ACBBB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9ED597C0ADE94D388AFFEB46</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3EDD22542556494A97D25B28</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>9FB763A7DCA749F7B5FAFCB1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BA68FB4C3BA7447F9B2138B5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A09BA4C6E28E4ADABE9279FA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>951E66269A724D598B1A39F9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A1BF772005AF4B5AAEC8CB72</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A389F37400B4492BA568CAFF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A920687EF16C413D91A3A1F0</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>7886CF6558BE4FE386740D23</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>A97C1315365F47D8B3380319</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-TransitionFun-ECSlidingViewController.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>AB342813E2F74E4F835EBBA6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0B0AB1A3798A4843AD2B24B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>AB438B83D5F34AE7B640D135</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AB5D2F9FECFB421892D1182D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo-ECSlidingViewController-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ADC76395C65E4A679B0B1681</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>80F36B3763C44569BB95B091</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AF37EEA03EA54B58881ABA12</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D6A329D2267347BBB7E44683</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B07A32185B4F45128B3A6AFB</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-LayoutDemo-ECSlidingViewController.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>B2E7F946B62347D5BAFC196F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>29207289750D4283A9F23981</string>
-				<string>42FCA23101EA44F490E013A9</string>
-				<string>D2C9486FFF7E4F79AB8286BB</string>
-				<string>AF37EEA03EA54B58881ABA12</string>
-				<string>F516B1C6AFE549198FBDCC0C</string>
-				<string>238EA7D177EB4FAB9D5A3655</string>
-				<string>CA114F7B068147D0B0F80878</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>B351D5B91ACD44409F2B731C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7890A641D03E4EE9BB98FEB3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B4363AE2C1D744618C100980</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>56A09442694D4E11AF49C1E6</string>
-				<string>34FD29AEFB7943B1BE03B53B</string>
-				<string>47EE943DCA33428BA643D147</string>
-				<string>68DBADCFD3D144649C7615F6</string>
-				<string>FEF6D6B6233742F1982004BC</string>
-				<string>E5467CA7810B4EC49E96F792</string>
-				<string>5827661A488E45BCB9B54E86</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>B54CDABD6F3949B4852991AB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D6A329D2267347BBB7E44683</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B58FEA3F69084C74A729B54F</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>NO</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>B5C86278C531420D846D42E7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B7A8EA957A1C47B6B3EA45FF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B863FA83F63B4E8AB18715E4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>ADC76395C65E4A679B0B1681</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B887D914A4244D338E66F948</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EDAD641B049A456EADFC151A</string>
-				<string>BC2BD4AE828E4886841BB89E</string>
-				<string>572562B7BC6C4BDFBBB2E183</string>
-				<string>D714C4A722564DCA9129B863</string>
-				<string>0D4CC7DADC504DC488F26F47</string>
-				<string>2DBA62E97F7949FD8F936655</string>
-				<string>57D37F12247C4AB882F52DAC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>BA68FB4C3BA7447F9B2138B5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ECSlidingConstants.h</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECSlidingConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BC2BD4AE828E4886841BB89E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05A0F7FF4A2241F7A02A4271</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>BCAE4F0F8B2A4D41B91193B4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BEC1168452FF49689EBF638A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3EDD22542556494A97D25B28</string>
-				<string>3613B000FCB149E1B702C04F</string>
-				<string>4999A34AA9714C869560F01B</string>
-				<string>E723638EC04E4B9B8467E891</string>
-				<string>7CA7854C66D24D94A76200A3</string>
-				<string>7877BA8020AF4533AB701BCD</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-TransitionFun</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BED8A47BA621475397D0ABF3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ECSlidingInteractiveTransition.m</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECSlidingInteractiveTransition.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C07E928F6BEB44419835424C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8D71EAADEA5445D7AA5C9EF3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>C0C2F6850286448584E13089</key>
-		<dict>
-			<key>fileRef</key>
-			<string>80F36B3763C44569BB95B091</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C182ACE7C3714049A2882E36</key>
-		<dict>
-			<key>fileRef</key>
-			<string>115D0AA1FEE44ED9BFA6FDC6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C244A4563C54447D9914C8BB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A97C1315365F47D8B3380319</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C2F15A24398944BC9587F236</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-LayoutDemo-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C43D89FFA2DE435A9EC21AC1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>6C57ADD1986E4FFCB085FFB0</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Pods-ECSlidingViewController-prefix.pch</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>C580AC6BDEE942389D258D78</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2DC9E5F6F94C4A55B633C130</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>C681802AD9D743E3B2F15288</key>
-		<dict>
-			<key>fileRef</key>
-			<string>115D0AA1FEE44ED9BFA6FDC6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C71497570ABC4133A4074557</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>48543482890F4F2DA34C3AEC</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>C99F1FA8CC2B4795B19221E3</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>EE65BB336AB04CB59EA18E50</string>
-			<key>buildPhases</key>
-			<array>
-				<string>28382F8BADDE4979854C1FA8</string>
-				<string>703CA9CBB23A4C49804E64FA</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>6C108F465DFF4293B3147B36</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-TransitionFun</string>
-			<key>productName</key>
-			<string>Pods-TransitionFun</string>
-			<key>productReference</key>
-			<string>4B1987B65C934009B52945DB</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>CA114F7B068147D0B0F80878</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F3CE12A4DC56427EBA1ACBBB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CDEA5973F2D5464081CC5483</key>
-		<dict>
-			<key>fileRef</key>
-			<string>80F36B3763C44569BB95B091</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CFAC7275820D48EEA2B422A7</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>D9FA22B238864DA6A7847C15</string>
-			<key>targetProxy</key>
-			<string>56E90D028802477C83BE004A</string>
-		</dict>
-		<key>D2C9486FFF7E4F79AB8286BB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BA68FB4C3BA7447F9B2138B5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D5CDB861922346179DC71211</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B07A32185B4F45128B3A6AFB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D60A817B0221416EA841BD1A</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>D6527E0BF259411397E9DFB5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7890A641D03E4EE9BB98FEB3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D6A329D2267347BBB7E44683</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ECSlidingInteractiveTransition.h</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECSlidingInteractiveTransition.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D714C4A722564DCA9129B863</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0B0AB1A3798A4843AD2B24B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>D79299614C764BFBB7F0C1EC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ECSlidingAnimationController.h</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECSlidingAnimationController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D8F6F0FAED3F4CCFBFF0D670</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>E3B164117B2C400097031550</string>
-				<string>B58FEA3F69084C74A729B54F</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>D9FA22B238864DA6A7847C15</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>7D38E6427062414FACAF28F3</string>
-			<key>buildPhases</key>
-			<array>
-				<string>B4363AE2C1D744618C100980</string>
-				<string>A920687EF16C413D91A3A1F0</string>
-				<string>1A5858B704E146E3B61E1499</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-ECSlidingViewController</string>
-			<key>productName</key>
-			<string>Pods-ECSlidingViewController</string>
-			<key>productReference</key>
-			<string>41BDD827DA074B90B26D375E</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>DA82464732184EF6AD51F3B8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D6A329D2267347BBB7E44683</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DBE0DD43F5374183862F9140</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>6C57ADD1986E4FFCB085FFB0</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Pods-ECSlidingViewController-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>DD443187B28247CCB02A8769</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>32419C2864D54AA5AFC09305</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Pods-LayoutDemo-ECSlidingViewController-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>E0F2931EE55E4D03A0739B66</key>
-		<dict>
-			<key>fileRef</key>
-			<string>092C56D382964781A8ABC9AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>E3B164117B2C400097031550</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>NO</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>E5467CA7810B4EC49E96F792</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8F972BB5274D476AA76C9A24</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E5A77ABDAF994AE98EAE2749</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>475248BE5E1948EE8019586F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>E6993C7BB61445CB8A6E6B87</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>64DFE6AD7E914D8FA47E5D2D</string>
-				<string>6C57ADD1986E4FFCB085FFB0</string>
-				<string>8F972BB5274D476AA76C9A24</string>
-				<string>19E8FD9227954EBABC12B848</string>
-				<string>743DBAF02BE84D44B6DE4902</string>
-				<string>32419C2864D54AA5AFC09305</string>
-				<string>2ED0AC593A9F4F839E88DA99</string>
-				<string>AB5D2F9FECFB421892D1182D</string>
-				<string>266FD155A6CE49BBA20886BC</string>
-				<string>3E3ABBA487184781AF292992</string>
-				<string>951E66269A724D598B1A39F9</string>
-				<string>65720D0358A3424BA412E35C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>E723638EC04E4B9B8467E891</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-TransitionFun-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EDAD641B049A456EADFC151A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>092C56D382964781A8ABC9AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>EE65BB336AB04CB59EA18E50</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>9ED597C0ADE94D388AFFEB46</string>
-				<string>F5FA03C4C4DC4C2A991D608D</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>F0B235E9AE644CF5BA0DECE0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ECSlidingViewController.m</string>
-			<key>path</key>
-			<string>ECSlidingViewController/ECSlidingViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1533D22221348B9A957F2E2</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>27EBABFA6F64419287E70912</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>09E7FA1FCEA1434083E1225F</string>
-			<key>remoteInfo</key>
-			<string>Pods-LayoutDemo-ECSlidingViewController</string>
-		</dict>
-		<key>F3CE12A4DC56427EBA1ACBBB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>UIViewController+ECSlidingViewController.h</string>
-			<key>path</key>
-			<string>ECSlidingViewController/UIViewController+ECSlidingViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F516B1C6AFE549198FBDCC0C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>115D0AA1FEE44ED9BFA6FDC6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F5FA03C4C4DC4C2A991D608D</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3EDD22542556494A97D25B28</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>F7B56F87F9A049AB8AA237D2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F3CE12A4DC56427EBA1ACBBB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FC818F6A10484B7B9502766C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4951697730A14BE2BCB4F678</string>
-				<string>37E2707459334890AB714C1E</string>
-				<string>BEC1168452FF49689EBF638A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Targets Support Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FEC80DF6B0F447B594AB0D12</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FEF6D6B6233742F1982004BC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F0B235E9AE644CF5BA0DECE0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fobjc-arc</string>
-			</dict>
-		</dict>
-		<key>FF937A6AC8504307B44B38FB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5609A3734828446587B61150</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>27EBABFA6F64419287E70912</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		015F32CA0DA741C5A9A828AD /* ECSlidingAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A0F7FF4A2241F7A02A4271 /* ECSlidingAnimationController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		0D4CC7DADC504DC488F26F47 /* ECSlidingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F0B235E9AE644CF5BA0DECE0 /* ECSlidingViewController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		238EA7D177EB4FAB9D5A3655 /* ECSlidingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7890A641D03E4EE9BB98FEB3 /* ECSlidingViewController.h */; };
+		2690AD410CC44AFB98D42F6D /* ECSlidingAnimationController.h in Headers */ = {isa = PBXBuildFile; fileRef = D79299614C764BFBB7F0C1EC /* ECSlidingAnimationController.h */; };
+		29207289750D4283A9F23981 /* ECPercentDrivenInteractiveTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 5609A3734828446587B61150 /* ECPercentDrivenInteractiveTransition.h */; };
+		2DBA62E97F7949FD8F936655 /* Pods-LayoutDemo-ECSlidingViewController-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2ED0AC593A9F4F839E88DA99 /* Pods-LayoutDemo-ECSlidingViewController-dummy.m */; };
+		2DC9E5F6F94C4A55B633C130 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80F36B3763C44569BB95B091 /* Foundation.framework */; };
+		34FD29AEFB7943B1BE03B53B /* ECSlidingAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A0F7FF4A2241F7A02A4271 /* ECSlidingAnimationController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		3CFAA80265F94F81AB01E346 /* ECSlidingConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = BA68FB4C3BA7447F9B2138B5 /* ECSlidingConstants.h */; };
+		42FCA23101EA44F490E013A9 /* ECSlidingAnimationController.h in Headers */ = {isa = PBXBuildFile; fileRef = D79299614C764BFBB7F0C1EC /* ECSlidingAnimationController.h */; };
+		4488690758604C8F9D6A860A /* ECPercentDrivenInteractiveTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 5609A3734828446587B61150 /* ECPercentDrivenInteractiveTransition.h */; };
+		475248BE5E1948EE8019586F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80F36B3763C44569BB95B091 /* Foundation.framework */; };
+		47EE943DCA33428BA643D147 /* ECSlidingInteractiveTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = BED8A47BA621475397D0ABF3 /* ECSlidingInteractiveTransition.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		4859D347BD254042A7AC6B5B /* Pods-TransitionFun-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E723638EC04E4B9B8467E891 /* Pods-TransitionFun-dummy.m */; };
+		4B3AC5F143944B00963BD519 /* Pods-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B7A8EA957A1C47B6B3EA45FF /* Pods-dummy.m */; };
+		56A09442694D4E11AF49C1E6 /* ECPercentDrivenInteractiveTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 092C56D382964781A8ABC9AA /* ECPercentDrivenInteractiveTransition.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		572562B7BC6C4BDFBBB2E183 /* ECSlidingInteractiveTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = BED8A47BA621475397D0ABF3 /* ECSlidingInteractiveTransition.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		57D37F12247C4AB882F52DAC /* UIViewController+ECSlidingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D71EAADEA5445D7AA5C9EF3 /* UIViewController+ECSlidingViewController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		5827661A488E45BCB9B54E86 /* UIViewController+ECSlidingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D71EAADEA5445D7AA5C9EF3 /* UIViewController+ECSlidingViewController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		5A87D753CBB74F5FA9566F9F /* libPods-ECSlidingViewController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 41BDD827DA074B90B26D375E /* libPods-ECSlidingViewController.a */; };
+		5AA59CFDD592431CBEC30776 /* Pods-LayoutDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BC56AF1A83E491FBEA8A8C4 /* Pods-LayoutDemo-dummy.m */; };
+		68DBADCFD3D144649C7615F6 /* ECSlidingSegue.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B0AB1A3798A4843AD2B24B0 /* ECSlidingSegue.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		6ABFE2B48C6345C0987E3FEA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80F36B3763C44569BB95B091 /* Foundation.framework */; };
+		7886CF6558BE4FE386740D23 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80F36B3763C44569BB95B091 /* Foundation.framework */; };
+		7E09B382BB1544C8A47C2786 /* ECSlidingAnimationController.h in Headers */ = {isa = PBXBuildFile; fileRef = D79299614C764BFBB7F0C1EC /* ECSlidingAnimationController.h */; };
+		8062C39962DF4F8AB06BAF08 /* ECSlidingInteractiveTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = BED8A47BA621475397D0ABF3 /* ECSlidingInteractiveTransition.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		9A1E6AFC820D4912B9A8B1D7 /* ECSlidingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F0B235E9AE644CF5BA0DECE0 /* ECSlidingViewController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		9D8455543EF84ED6B1C64E1A /* UIViewController+ECSlidingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F3CE12A4DC56427EBA1ACBBB /* UIViewController+ECSlidingViewController.h */; };
+		9FB763A7DCA749F7B5FAFCB1 /* ECSlidingConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = BA68FB4C3BA7447F9B2138B5 /* ECSlidingConstants.h */; };
+		A09BA4C6E28E4ADABE9279FA /* Pods-TransitionFun-ECSlidingViewController-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 951E66269A724D598B1A39F9 /* Pods-TransitionFun-ECSlidingViewController-dummy.m */; };
+		AB342813E2F74E4F835EBBA6 /* ECSlidingSegue.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B0AB1A3798A4843AD2B24B0 /* ECSlidingSegue.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		AF37EEA03EA54B58881ABA12 /* ECSlidingInteractiveTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = D6A329D2267347BBB7E44683 /* ECSlidingInteractiveTransition.h */; };
+		B351D5B91ACD44409F2B731C /* ECSlidingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7890A641D03E4EE9BB98FEB3 /* ECSlidingViewController.h */; };
+		B54CDABD6F3949B4852991AB /* ECSlidingInteractiveTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = D6A329D2267347BBB7E44683 /* ECSlidingInteractiveTransition.h */; };
+		BC2BD4AE828E4886841BB89E /* ECSlidingAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A0F7FF4A2241F7A02A4271 /* ECSlidingAnimationController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		C07E928F6BEB44419835424C /* UIViewController+ECSlidingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D71EAADEA5445D7AA5C9EF3 /* UIViewController+ECSlidingViewController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		C0C2F6850286448584E13089 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80F36B3763C44569BB95B091 /* Foundation.framework */; };
+		C182ACE7C3714049A2882E36 /* ECSlidingSegue.h in Headers */ = {isa = PBXBuildFile; fileRef = 115D0AA1FEE44ED9BFA6FDC6 /* ECSlidingSegue.h */; };
+		C244A4563C54447D9914C8BB /* libPods-TransitionFun-ECSlidingViewController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A97C1315365F47D8B3380319 /* libPods-TransitionFun-ECSlidingViewController.a */; };
+		C681802AD9D743E3B2F15288 /* ECSlidingSegue.h in Headers */ = {isa = PBXBuildFile; fileRef = 115D0AA1FEE44ED9BFA6FDC6 /* ECSlidingSegue.h */; };
+		CA114F7B068147D0B0F80878 /* UIViewController+ECSlidingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F3CE12A4DC56427EBA1ACBBB /* UIViewController+ECSlidingViewController.h */; };
+		CDEA5973F2D5464081CC5483 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80F36B3763C44569BB95B091 /* Foundation.framework */; };
+		D2C9486FFF7E4F79AB8286BB /* ECSlidingConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = BA68FB4C3BA7447F9B2138B5 /* ECSlidingConstants.h */; };
+		D5CDB861922346179DC71211 /* libPods-LayoutDemo-ECSlidingViewController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B07A32185B4F45128B3A6AFB /* libPods-LayoutDemo-ECSlidingViewController.a */; };
+		D6527E0BF259411397E9DFB5 /* ECSlidingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7890A641D03E4EE9BB98FEB3 /* ECSlidingViewController.h */; };
+		D714C4A722564DCA9129B863 /* ECSlidingSegue.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B0AB1A3798A4843AD2B24B0 /* ECSlidingSegue.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		DA82464732184EF6AD51F3B8 /* ECSlidingInteractiveTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = D6A329D2267347BBB7E44683 /* ECSlidingInteractiveTransition.h */; };
+		E0F2931EE55E4D03A0739B66 /* ECPercentDrivenInteractiveTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 092C56D382964781A8ABC9AA /* ECPercentDrivenInteractiveTransition.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		E5467CA7810B4EC49E96F792 /* Pods-ECSlidingViewController-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F972BB5274D476AA76C9A24 /* Pods-ECSlidingViewController-dummy.m */; };
+		EDAD641B049A456EADFC151A /* ECPercentDrivenInteractiveTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 092C56D382964781A8ABC9AA /* ECPercentDrivenInteractiveTransition.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		F516B1C6AFE549198FBDCC0C /* ECSlidingSegue.h in Headers */ = {isa = PBXBuildFile; fileRef = 115D0AA1FEE44ED9BFA6FDC6 /* ECSlidingSegue.h */; };
+		F7B56F87F9A049AB8AA237D2 /* UIViewController+ECSlidingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F3CE12A4DC56427EBA1ACBBB /* UIViewController+ECSlidingViewController.h */; };
+		FEF6D6B6233742F1982004BC /* ECSlidingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F0B235E9AE644CF5BA0DECE0 /* ECSlidingViewController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		FF937A6AC8504307B44B38FB /* ECPercentDrivenInteractiveTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 5609A3734828446587B61150 /* ECPercentDrivenInteractiveTransition.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1AEEC0B2CCCB41508CDEDB8B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 27EBABFA6F64419287E70912 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5607EBE399554D25A42963E6;
+			remoteInfo = "Pods-TransitionFun-ECSlidingViewController";
+		};
+		56E90D028802477C83BE004A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 27EBABFA6F64419287E70912 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D9FA22B238864DA6A7847C15;
+			remoteInfo = "Pods-ECSlidingViewController";
+		};
+		F1533D22221348B9A957F2E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 27EBABFA6F64419287E70912 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 09E7FA1FCEA1434083E1225F;
+			remoteInfo = "Pods-LayoutDemo-ECSlidingViewController";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		05A0F7FF4A2241F7A02A4271 /* ECSlidingAnimationController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ECSlidingAnimationController.m; path = ECSlidingViewController/ECSlidingAnimationController.m; sourceTree = "<group>"; };
+		092C56D382964781A8ABC9AA /* ECPercentDrivenInteractiveTransition.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ECPercentDrivenInteractiveTransition.m; path = ECSlidingViewController/ECPercentDrivenInteractiveTransition.m; sourceTree = "<group>"; };
+		0B0AB1A3798A4843AD2B24B0 /* ECSlidingSegue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ECSlidingSegue.m; path = ECSlidingViewController/ECSlidingSegue.m; sourceTree = "<group>"; };
+		115D0AA1FEE44ED9BFA6FDC6 /* ECSlidingSegue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ECSlidingSegue.h; path = ECSlidingViewController/ECSlidingSegue.h; sourceTree = "<group>"; };
+		19E8FD9227954EBABC12B848 /* Pods-ECSlidingViewController-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-ECSlidingViewController-prefix.pch"; sourceTree = "<group>"; };
+		248080785E4C400DAD6F9FB4 /* libPods-LayoutDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LayoutDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		266FD155A6CE49BBA20886BC /* Pods-TransitionFun-ECSlidingViewController.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TransitionFun-ECSlidingViewController.xcconfig"; sourceTree = "<group>"; };
+		2ED0AC593A9F4F839E88DA99 /* Pods-LayoutDemo-ECSlidingViewController-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-LayoutDemo-ECSlidingViewController-dummy.m"; sourceTree = "<group>"; };
+		32419C2864D54AA5AFC09305 /* Pods-LayoutDemo-ECSlidingViewController-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-LayoutDemo-ECSlidingViewController-Private.xcconfig"; sourceTree = "<group>"; };
+		3613B000FCB149E1B702C04F /* Pods-TransitionFun-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-TransitionFun-acknowledgements.markdown"; sourceTree = "<group>"; };
+		3E3ABBA487184781AF292992 /* Pods-TransitionFun-ECSlidingViewController-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TransitionFun-ECSlidingViewController-Private.xcconfig"; sourceTree = "<group>"; };
+		3EDD22542556494A97D25B28 /* Pods-TransitionFun.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TransitionFun.xcconfig"; sourceTree = "<group>"; };
+		41BDD827DA074B90B26D375E /* libPods-ECSlidingViewController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ECSlidingViewController.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		48543482890F4F2DA34C3AEC /* Pods-LayoutDemo.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-LayoutDemo.xcconfig"; sourceTree = "<group>"; };
+		4999A34AA9714C869560F01B /* Pods-TransitionFun-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TransitionFun-acknowledgements.plist"; sourceTree = "<group>"; };
+		4B1987B65C934009B52945DB /* libPods-TransitionFun.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TransitionFun.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		550F6B23D30B4797837A9E0E /* Pods-LayoutDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-LayoutDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
+		5609A3734828446587B61150 /* ECPercentDrivenInteractiveTransition.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ECPercentDrivenInteractiveTransition.h; path = ECSlidingViewController/ECPercentDrivenInteractiveTransition.h; sourceTree = "<group>"; };
+		64DFE6AD7E914D8FA47E5D2D /* Pods-ECSlidingViewController.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ECSlidingViewController.xcconfig"; sourceTree = "<group>"; };
+		65720D0358A3424BA412E35C /* Pods-TransitionFun-ECSlidingViewController-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TransitionFun-ECSlidingViewController-prefix.pch"; sourceTree = "<group>"; };
+		6C57ADD1986E4FFCB085FFB0 /* Pods-ECSlidingViewController-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ECSlidingViewController-Private.xcconfig"; sourceTree = "<group>"; };
+		743DBAF02BE84D44B6DE4902 /* Pods-LayoutDemo-ECSlidingViewController.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-LayoutDemo-ECSlidingViewController.xcconfig"; sourceTree = "<group>"; };
+		7877BA8020AF4533AB701BCD /* Pods-TransitionFun-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TransitionFun-resources.sh"; sourceTree = "<group>"; };
+		7890A641D03E4EE9BB98FEB3 /* ECSlidingViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ECSlidingViewController.h; path = ECSlidingViewController/ECSlidingViewController.h; sourceTree = "<group>"; };
+		7969D9DA48FE427482D1D4ED /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		7CA7854C66D24D94A76200A3 /* Pods-TransitionFun-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TransitionFun-environment.h"; sourceTree = "<group>"; };
+		80F36B3763C44569BB95B091 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		8D71EAADEA5445D7AA5C9EF3 /* UIViewController+ECSlidingViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+ECSlidingViewController.m"; path = "ECSlidingViewController/UIViewController+ECSlidingViewController.m"; sourceTree = "<group>"; };
+		8F972BB5274D476AA76C9A24 /* Pods-ECSlidingViewController-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ECSlidingViewController-dummy.m"; sourceTree = "<group>"; };
+		951E66269A724D598B1A39F9 /* Pods-TransitionFun-ECSlidingViewController-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TransitionFun-ECSlidingViewController-dummy.m"; sourceTree = "<group>"; };
+		95241B9E4D4C4E33BB2892F8 /* Pods-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-environment.h"; sourceTree = "<group>"; };
+		9BC56AF1A83E491FBEA8A8C4 /* Pods-LayoutDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-LayoutDemo-dummy.m"; sourceTree = "<group>"; };
+		A1BF772005AF4B5AAEC8CB72 /* Pods-LayoutDemo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-LayoutDemo-resources.sh"; sourceTree = "<group>"; };
+		A389F37400B4492BA568CAFF /* Pods-LayoutDemo-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-LayoutDemo-environment.h"; sourceTree = "<group>"; };
+		A97C1315365F47D8B3380319 /* libPods-TransitionFun-ECSlidingViewController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TransitionFun-ECSlidingViewController.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB438B83D5F34AE7B640D135 /* Pods-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-resources.sh"; sourceTree = "<group>"; };
+		AB5D2F9FECFB421892D1182D /* Pods-LayoutDemo-ECSlidingViewController-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-LayoutDemo-ECSlidingViewController-prefix.pch"; sourceTree = "<group>"; };
+		B07A32185B4F45128B3A6AFB /* libPods-LayoutDemo-ECSlidingViewController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LayoutDemo-ECSlidingViewController.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B5C86278C531420D846D42E7 /* Pods-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-acknowledgements.markdown"; sourceTree = "<group>"; };
+		B7A8EA957A1C47B6B3EA45FF /* Pods-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-dummy.m"; sourceTree = "<group>"; };
+		BA68FB4C3BA7447F9B2138B5 /* ECSlidingConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ECSlidingConstants.h; path = ECSlidingViewController/ECSlidingConstants.h; sourceTree = "<group>"; };
+		BCAE4F0F8B2A4D41B91193B4 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.xcconfig; sourceTree = "<group>"; };
+		BED8A47BA621475397D0ABF3 /* ECSlidingInteractiveTransition.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ECSlidingInteractiveTransition.m; path = ECSlidingViewController/ECSlidingInteractiveTransition.m; sourceTree = "<group>"; };
+		C2F15A24398944BC9587F236 /* Pods-LayoutDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-LayoutDemo-acknowledgements.plist"; sourceTree = "<group>"; };
+		D60A817B0221416EA841BD1A /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6A329D2267347BBB7E44683 /* ECSlidingInteractiveTransition.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ECSlidingInteractiveTransition.h; path = ECSlidingViewController/ECSlidingInteractiveTransition.h; sourceTree = "<group>"; };
+		D79299614C764BFBB7F0C1EC /* ECSlidingAnimationController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ECSlidingAnimationController.h; path = ECSlidingViewController/ECSlidingAnimationController.h; sourceTree = "<group>"; };
+		E723638EC04E4B9B8467E891 /* Pods-TransitionFun-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TransitionFun-dummy.m"; sourceTree = "<group>"; };
+		F0B235E9AE644CF5BA0DECE0 /* ECSlidingViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ECSlidingViewController.m; path = ECSlidingViewController/ECSlidingViewController.m; sourceTree = "<group>"; };
+		F3CE12A4DC56427EBA1ACBBB /* UIViewController+ECSlidingViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+ECSlidingViewController.h"; path = "ECSlidingViewController/UIViewController+ECSlidingViewController.h"; sourceTree = "<group>"; };
+		FEC80DF6B0F447B594AB0D12 /* Pods-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-acknowledgements.plist"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6ED900087B8543EA9DD230A6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ABFE2B48C6345C0987E3FEA /* Foundation.framework in Frameworks */,
+				D5CDB861922346179DC71211 /* libPods-LayoutDemo-ECSlidingViewController.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		703CA9CBB23A4C49804E64FA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0C2F6850286448584E13089 /* Foundation.framework in Frameworks */,
+				C244A4563C54447D9914C8BB /* libPods-TransitionFun-ECSlidingViewController.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		94F96492953741C498340C79 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CDEA5973F2D5464081CC5483 /* Foundation.framework in Frameworks */,
+				5A87D753CBB74F5FA9566F9F /* libPods-ECSlidingViewController.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A920687EF16C413D91A3A1F0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7886CF6558BE4FE386740D23 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C580AC6BDEE942389D258D78 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2DC9E5F6F94C4A55B633C130 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5A77ABDAF994AE98EAE2749 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				475248BE5E1948EE8019586F /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		05EF9BE4EEEB466A811E8459 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D60A817B0221416EA841BD1A /* libPods.a */,
+				41BDD827DA074B90B26D375E /* libPods-ECSlidingViewController.a */,
+				248080785E4C400DAD6F9FB4 /* libPods-LayoutDemo.a */,
+				B07A32185B4F45128B3A6AFB /* libPods-LayoutDemo-ECSlidingViewController.a */,
+				4B1987B65C934009B52945DB /* libPods-TransitionFun.a */,
+				A97C1315365F47D8B3380319 /* libPods-TransitionFun-ECSlidingViewController.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		37E2707459334890AB714C1E /* Pods-LayoutDemo */ = {
+			isa = PBXGroup;
+			children = (
+				48543482890F4F2DA34C3AEC /* Pods-LayoutDemo.xcconfig */,
+				550F6B23D30B4797837A9E0E /* Pods-LayoutDemo-acknowledgements.markdown */,
+				C2F15A24398944BC9587F236 /* Pods-LayoutDemo-acknowledgements.plist */,
+				9BC56AF1A83E491FBEA8A8C4 /* Pods-LayoutDemo-dummy.m */,
+				A389F37400B4492BA568CAFF /* Pods-LayoutDemo-environment.h */,
+				A1BF772005AF4B5AAEC8CB72 /* Pods-LayoutDemo-resources.sh */,
+			);
+			name = "Pods-LayoutDemo";
+			sourceTree = "<group>";
+		};
+		4951697730A14BE2BCB4F678 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				BCAE4F0F8B2A4D41B91193B4 /* Pods.xcconfig */,
+				B5C86278C531420D846D42E7 /* Pods-acknowledgements.markdown */,
+				FEC80DF6B0F447B594AB0D12 /* Pods-acknowledgements.plist */,
+				B7A8EA957A1C47B6B3EA45FF /* Pods-dummy.m */,
+				95241B9E4D4C4E33BB2892F8 /* Pods-environment.h */,
+				AB438B83D5F34AE7B640D135 /* Pods-resources.sh */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		791A2DEEE38E427598328B33 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				8108F55519FC448CB5E779DF /* ECSlidingViewController */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		8108F55519FC448CB5E779DF /* ECSlidingViewController */ = {
+			isa = PBXGroup;
+			children = (
+				5609A3734828446587B61150 /* ECPercentDrivenInteractiveTransition.h */,
+				092C56D382964781A8ABC9AA /* ECPercentDrivenInteractiveTransition.m */,
+				D79299614C764BFBB7F0C1EC /* ECSlidingAnimationController.h */,
+				05A0F7FF4A2241F7A02A4271 /* ECSlidingAnimationController.m */,
+				BA68FB4C3BA7447F9B2138B5 /* ECSlidingConstants.h */,
+				D6A329D2267347BBB7E44683 /* ECSlidingInteractiveTransition.h */,
+				BED8A47BA621475397D0ABF3 /* ECSlidingInteractiveTransition.m */,
+				115D0AA1FEE44ED9BFA6FDC6 /* ECSlidingSegue.h */,
+				0B0AB1A3798A4843AD2B24B0 /* ECSlidingSegue.m */,
+				7890A641D03E4EE9BB98FEB3 /* ECSlidingViewController.h */,
+				F0B235E9AE644CF5BA0DECE0 /* ECSlidingViewController.m */,
+				F3CE12A4DC56427EBA1ACBBB /* UIViewController+ECSlidingViewController.h */,
+				8D71EAADEA5445D7AA5C9EF3 /* UIViewController+ECSlidingViewController.m */,
+				E6993C7BB61445CB8A6E6B87 /* Support Files */,
+			);
+			name = ECSlidingViewController;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		8CF9B69AA66E4C74A9B70153 = {
+			isa = PBXGroup;
+			children = (
+				7969D9DA48FE427482D1D4ED /* Podfile */,
+				791A2DEEE38E427598328B33 /* Development Pods */,
+				B863FA83F63B4E8AB18715E4 /* Frameworks */,
+				05EF9BE4EEEB466A811E8459 /* Products */,
+				FC818F6A10484B7B9502766C /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		ADC76395C65E4A679B0B1681 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				80F36B3763C44569BB95B091 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		B863FA83F63B4E8AB18715E4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ADC76395C65E4A679B0B1681 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		BEC1168452FF49689EBF638A /* Pods-TransitionFun */ = {
+			isa = PBXGroup;
+			children = (
+				3EDD22542556494A97D25B28 /* Pods-TransitionFun.xcconfig */,
+				3613B000FCB149E1B702C04F /* Pods-TransitionFun-acknowledgements.markdown */,
+				4999A34AA9714C869560F01B /* Pods-TransitionFun-acknowledgements.plist */,
+				E723638EC04E4B9B8467E891 /* Pods-TransitionFun-dummy.m */,
+				7CA7854C66D24D94A76200A3 /* Pods-TransitionFun-environment.h */,
+				7877BA8020AF4533AB701BCD /* Pods-TransitionFun-resources.sh */,
+			);
+			name = "Pods-TransitionFun";
+			sourceTree = "<group>";
+		};
+		E6993C7BB61445CB8A6E6B87 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				64DFE6AD7E914D8FA47E5D2D /* Pods-ECSlidingViewController.xcconfig */,
+				6C57ADD1986E4FFCB085FFB0 /* Pods-ECSlidingViewController-Private.xcconfig */,
+				8F972BB5274D476AA76C9A24 /* Pods-ECSlidingViewController-dummy.m */,
+				19E8FD9227954EBABC12B848 /* Pods-ECSlidingViewController-prefix.pch */,
+				743DBAF02BE84D44B6DE4902 /* Pods-LayoutDemo-ECSlidingViewController.xcconfig */,
+				32419C2864D54AA5AFC09305 /* Pods-LayoutDemo-ECSlidingViewController-Private.xcconfig */,
+				2ED0AC593A9F4F839E88DA99 /* Pods-LayoutDemo-ECSlidingViewController-dummy.m */,
+				AB5D2F9FECFB421892D1182D /* Pods-LayoutDemo-ECSlidingViewController-prefix.pch */,
+				266FD155A6CE49BBA20886BC /* Pods-TransitionFun-ECSlidingViewController.xcconfig */,
+				3E3ABBA487184781AF292992 /* Pods-TransitionFun-ECSlidingViewController-Private.xcconfig */,
+				951E66269A724D598B1A39F9 /* Pods-TransitionFun-ECSlidingViewController-dummy.m */,
+				65720D0358A3424BA412E35C /* Pods-TransitionFun-ECSlidingViewController-prefix.pch */,
+			);
+			name = "Support Files";
+			sourceTree = SOURCE_ROOT;
+		};
+		FC818F6A10484B7B9502766C /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				4951697730A14BE2BCB4F678 /* Pods */,
+				37E2707459334890AB714C1E /* Pods-LayoutDemo */,
+				BEC1168452FF49689EBF638A /* Pods-TransitionFun */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		1A5858B704E146E3B61E1499 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4488690758604C8F9D6A860A /* ECPercentDrivenInteractiveTransition.h in Headers */,
+				2690AD410CC44AFB98D42F6D /* ECSlidingAnimationController.h in Headers */,
+				3CFAA80265F94F81AB01E346 /* ECSlidingConstants.h in Headers */,
+				B54CDABD6F3949B4852991AB /* ECSlidingInteractiveTransition.h in Headers */,
+				C681802AD9D743E3B2F15288 /* ECSlidingSegue.h in Headers */,
+				B351D5B91ACD44409F2B731C /* ECSlidingViewController.h in Headers */,
+				9D8455543EF84ED6B1C64E1A /* UIViewController+ECSlidingViewController.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6A42AACD2EC94668801FB31E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF937A6AC8504307B44B38FB /* ECPercentDrivenInteractiveTransition.h in Headers */,
+				7E09B382BB1544C8A47C2786 /* ECSlidingAnimationController.h in Headers */,
+				9FB763A7DCA749F7B5FAFCB1 /* ECSlidingConstants.h in Headers */,
+				DA82464732184EF6AD51F3B8 /* ECSlidingInteractiveTransition.h in Headers */,
+				C182ACE7C3714049A2882E36 /* ECSlidingSegue.h in Headers */,
+				D6527E0BF259411397E9DFB5 /* ECSlidingViewController.h in Headers */,
+				F7B56F87F9A049AB8AA237D2 /* UIViewController+ECSlidingViewController.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B2E7F946B62347D5BAFC196F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				29207289750D4283A9F23981 /* ECPercentDrivenInteractiveTransition.h in Headers */,
+				42FCA23101EA44F490E013A9 /* ECSlidingAnimationController.h in Headers */,
+				D2C9486FFF7E4F79AB8286BB /* ECSlidingConstants.h in Headers */,
+				AF37EEA03EA54B58881ABA12 /* ECSlidingInteractiveTransition.h in Headers */,
+				F516B1C6AFE549198FBDCC0C /* ECSlidingSegue.h in Headers */,
+				238EA7D177EB4FAB9D5A3655 /* ECSlidingViewController.h in Headers */,
+				CA114F7B068147D0B0F80878 /* UIViewController+ECSlidingViewController.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		09E7FA1FCEA1434083E1225F /* Pods-LayoutDemo-ECSlidingViewController */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 54BF60C37764452F917688A3 /* Build configuration list for PBXNativeTarget "Pods-LayoutDemo-ECSlidingViewController" */;
+			buildPhases = (
+				B887D914A4244D338E66F948 /* Sources */,
+				E5A77ABDAF994AE98EAE2749 /* Frameworks */,
+				B2E7F946B62347D5BAFC196F /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-LayoutDemo-ECSlidingViewController";
+			productName = "Pods-LayoutDemo-ECSlidingViewController";
+			productReference = B07A32185B4F45128B3A6AFB /* libPods-LayoutDemo-ECSlidingViewController.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		3E89CAB1367F47378AAF44F7 /* Pods */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1ECDC9401E6B479996E25C18 /* Build configuration list for PBXNativeTarget "Pods" */;
+			buildPhases = (
+				789C5D6385DD40CDB3B87BC3 /* Sources */,
+				94F96492953741C498340C79 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CFAC7275820D48EEA2B422A7 /* PBXTargetDependency */,
+			);
+			name = Pods;
+			productName = Pods;
+			productReference = D60A817B0221416EA841BD1A /* libPods.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		4261EB551A7D4ABDAA4189E5 /* Pods-LayoutDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 38F7F851D6EA47C9AC4682D3 /* Build configuration list for PBXNativeTarget "Pods-LayoutDemo" */;
+			buildPhases = (
+				0933D46FF1B74BB8B59E866A /* Sources */,
+				6ED900087B8543EA9DD230A6 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1E57B5648C1D4537AE30F5B9 /* PBXTargetDependency */,
+			);
+			name = "Pods-LayoutDemo";
+			productName = "Pods-LayoutDemo";
+			productReference = 248080785E4C400DAD6F9FB4 /* libPods-LayoutDemo.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		5607EBE399554D25A42963E6 /* Pods-TransitionFun-ECSlidingViewController */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9816D1A9150243E286D958CF /* Build configuration list for PBXNativeTarget "Pods-TransitionFun-ECSlidingViewController" */;
+			buildPhases = (
+				07CE8AF7EA58464F9EA164A7 /* Sources */,
+				C580AC6BDEE942389D258D78 /* Frameworks */,
+				6A42AACD2EC94668801FB31E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-TransitionFun-ECSlidingViewController";
+			productName = "Pods-TransitionFun-ECSlidingViewController";
+			productReference = A97C1315365F47D8B3380319 /* libPods-TransitionFun-ECSlidingViewController.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		C99F1FA8CC2B4795B19221E3 /* Pods-TransitionFun */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EE65BB336AB04CB59EA18E50 /* Build configuration list for PBXNativeTarget "Pods-TransitionFun" */;
+			buildPhases = (
+				28382F8BADDE4979854C1FA8 /* Sources */,
+				703CA9CBB23A4C49804E64FA /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6C108F465DFF4293B3147B36 /* PBXTargetDependency */,
+			);
+			name = "Pods-TransitionFun";
+			productName = "Pods-TransitionFun";
+			productReference = 4B1987B65C934009B52945DB /* libPods-TransitionFun.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		D9FA22B238864DA6A7847C15 /* Pods-ECSlidingViewController */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7D38E6427062414FACAF28F3 /* Build configuration list for PBXNativeTarget "Pods-ECSlidingViewController" */;
+			buildPhases = (
+				B4363AE2C1D744618C100980 /* Sources */,
+				A920687EF16C413D91A3A1F0 /* Frameworks */,
+				1A5858B704E146E3B61E1499 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-ECSlidingViewController";
+			productName = "Pods-ECSlidingViewController";
+			productReference = 41BDD827DA074B90B26D375E /* libPods-ECSlidingViewController.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		27EBABFA6F64419287E70912 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0500;
+			};
+			buildConfigurationList = D8F6F0FAED3F4CCFBFF0D670 /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 8CF9B69AA66E4C74A9B70153;
+			productRefGroup = 05EF9BE4EEEB466A811E8459 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3E89CAB1367F47378AAF44F7 /* Pods */,
+				D9FA22B238864DA6A7847C15 /* Pods-ECSlidingViewController */,
+				4261EB551A7D4ABDAA4189E5 /* Pods-LayoutDemo */,
+				09E7FA1FCEA1434083E1225F /* Pods-LayoutDemo-ECSlidingViewController */,
+				C99F1FA8CC2B4795B19221E3 /* Pods-TransitionFun */,
+				5607EBE399554D25A42963E6 /* Pods-TransitionFun-ECSlidingViewController */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		07CE8AF7EA58464F9EA164A7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E0F2931EE55E4D03A0739B66 /* ECPercentDrivenInteractiveTransition.m in Sources */,
+				015F32CA0DA741C5A9A828AD /* ECSlidingAnimationController.m in Sources */,
+				8062C39962DF4F8AB06BAF08 /* ECSlidingInteractiveTransition.m in Sources */,
+				AB342813E2F74E4F835EBBA6 /* ECSlidingSegue.m in Sources */,
+				9A1E6AFC820D4912B9A8B1D7 /* ECSlidingViewController.m in Sources */,
+				A09BA4C6E28E4ADABE9279FA /* Pods-TransitionFun-ECSlidingViewController-dummy.m in Sources */,
+				C07E928F6BEB44419835424C /* UIViewController+ECSlidingViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0933D46FF1B74BB8B59E866A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AA59CFDD592431CBEC30776 /* Pods-LayoutDemo-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		28382F8BADDE4979854C1FA8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4859D347BD254042A7AC6B5B /* Pods-TransitionFun-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		789C5D6385DD40CDB3B87BC3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4B3AC5F143944B00963BD519 /* Pods-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B4363AE2C1D744618C100980 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				56A09442694D4E11AF49C1E6 /* ECPercentDrivenInteractiveTransition.m in Sources */,
+				34FD29AEFB7943B1BE03B53B /* ECSlidingAnimationController.m in Sources */,
+				47EE943DCA33428BA643D147 /* ECSlidingInteractiveTransition.m in Sources */,
+				68DBADCFD3D144649C7615F6 /* ECSlidingSegue.m in Sources */,
+				FEF6D6B6233742F1982004BC /* ECSlidingViewController.m in Sources */,
+				E5467CA7810B4EC49E96F792 /* Pods-ECSlidingViewController-dummy.m in Sources */,
+				5827661A488E45BCB9B54E86 /* UIViewController+ECSlidingViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B887D914A4244D338E66F948 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EDAD641B049A456EADFC151A /* ECPercentDrivenInteractiveTransition.m in Sources */,
+				BC2BD4AE828E4886841BB89E /* ECSlidingAnimationController.m in Sources */,
+				572562B7BC6C4BDFBBB2E183 /* ECSlidingInteractiveTransition.m in Sources */,
+				D714C4A722564DCA9129B863 /* ECSlidingSegue.m in Sources */,
+				0D4CC7DADC504DC488F26F47 /* ECSlidingViewController.m in Sources */,
+				2DBA62E97F7949FD8F936655 /* Pods-LayoutDemo-ECSlidingViewController-dummy.m in Sources */,
+				57D37F12247C4AB882F52DAC /* UIViewController+ECSlidingViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1E57B5648C1D4537AE30F5B9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 09E7FA1FCEA1434083E1225F /* Pods-LayoutDemo-ECSlidingViewController */;
+			targetProxy = F1533D22221348B9A957F2E2 /* PBXContainerItemProxy */;
+		};
+		6C108F465DFF4293B3147B36 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5607EBE399554D25A42963E6 /* Pods-TransitionFun-ECSlidingViewController */;
+			targetProxy = 1AEEC0B2CCCB41508CDEDB8B /* PBXContainerItemProxy */;
+		};
+		CFAC7275820D48EEA2B422A7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D9FA22B238864DA6A7847C15 /* Pods-ECSlidingViewController */;
+			targetProxy = 56E90D028802477C83BE004A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		37F38BB4AB6048D68206A017 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3E3ABBA487184781AF292992 /* Pods-TransitionFun-ECSlidingViewController-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Pods-TransitionFun-ECSlidingViewController-prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3BB7AB75322C440AB6E0AA60 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 32419C2864D54AA5AFC09305 /* Pods-LayoutDemo-ECSlidingViewController-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Pods-LayoutDemo-ECSlidingViewController-prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5B42A92F4B5042399BA84719 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 48543482890F4F2DA34C3AEC /* Pods-LayoutDemo.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		6260FB9E7C8E4AE68D17E69A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3E3ABBA487184781AF292992 /* Pods-TransitionFun-ECSlidingViewController-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Pods-TransitionFun-ECSlidingViewController-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		700EDB93E66E4C9D99C2B664 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCAE4F0F8B2A4D41B91193B4 /* Pods.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		711813210CAA4293BE836D01 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCAE4F0F8B2A4D41B91193B4 /* Pods.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		9ED597C0ADE94D388AFFEB46 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3EDD22542556494A97D25B28 /* Pods-TransitionFun.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		B58FEA3F69084C74A729B54F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C43D89FFA2DE435A9EC21AC1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C57ADD1986E4FFCB085FFB0 /* Pods-ECSlidingViewController-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Pods-ECSlidingViewController-prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C71497570ABC4133A4074557 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 48543482890F4F2DA34C3AEC /* Pods-LayoutDemo.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		DBE0DD43F5374183862F9140 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C57ADD1986E4FFCB085FFB0 /* Pods-ECSlidingViewController-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Pods-ECSlidingViewController-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		DD443187B28247CCB02A8769 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 32419C2864D54AA5AFC09305 /* Pods-LayoutDemo-ECSlidingViewController-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Pods-LayoutDemo-ECSlidingViewController-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		E3B164117B2C400097031550 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COPY_PHASE_STRIP = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Debug;
+		};
+		F5FA03C4C4DC4C2A991D608D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3EDD22542556494A97D25B28 /* Pods-TransitionFun.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1ECDC9401E6B479996E25C18 /* Build configuration list for PBXNativeTarget "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				711813210CAA4293BE836D01 /* Debug */,
+				700EDB93E66E4C9D99C2B664 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		38F7F851D6EA47C9AC4682D3 /* Build configuration list for PBXNativeTarget "Pods-LayoutDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B42A92F4B5042399BA84719 /* Debug */,
+				C71497570ABC4133A4074557 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		54BF60C37764452F917688A3 /* Build configuration list for PBXNativeTarget "Pods-LayoutDemo-ECSlidingViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD443187B28247CCB02A8769 /* Debug */,
+				3BB7AB75322C440AB6E0AA60 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7D38E6427062414FACAF28F3 /* Build configuration list for PBXNativeTarget "Pods-ECSlidingViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DBE0DD43F5374183862F9140 /* Debug */,
+				C43D89FFA2DE435A9EC21AC1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9816D1A9150243E286D958CF /* Build configuration list for PBXNativeTarget "Pods-TransitionFun-ECSlidingViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6260FB9E7C8E4AE68D17E69A /* Debug */,
+				37F38BB4AB6048D68206A017 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D8F6F0FAED3F4CCFBFF0D670 /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E3B164117B2C400097031550 /* Debug */,
+				B58FEA3F69084C74A729B54F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EE65BB336AB04CB59EA18E50 /* Build configuration list for PBXNativeTarget "Pods-TransitionFun" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9ED597C0ADE94D388AFFEB46 /* Debug */,
+				F5FA03C4C4DC4C2A991D608D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 27EBABFA6F64419287E70912 /* Project object */;
+}


### PR DESCRIPTION
This is a quick fix. I created a new project under Example named ECSlidingViewController. Carthage will look into this and build the framework. 

For Swift, it's a benefit of supporting Carthage. Cocoapods, now, has some problems with project that mix Swift and Obj-c so this changes will help too.