### PR TITLE
Use generic ABS for mixed-architechture CGFloat

### DIFF
--- a/ECSlidingViewController/ECSlidingInteractiveTransition.m
+++ b/ECSlidingViewController/ECSlidingInteractiveTransition.m
@@ -52,7 +52,7 @@
     UIViewController *topViewController = [transitionContext viewControllerForKey:ECTransitionContextTopViewControllerKey];
     CGFloat finalLeftEdge = CGRectGetMinX([transitionContext finalFrameForViewController:topViewController]);
     CGFloat initialLeftEdge = CGRectGetMinX([transitionContext initialFrameForViewController:topViewController]);
-    CGFloat fullWidth = fabsf(finalLeftEdge - initialLeftEdge);
+    CGFloat fullWidth = ABS(finalLeftEdge - initialLeftEdge);
     
     self.positiveLeftToRight = initialLeftEdge < finalLeftEdge;
     self.fullWidth           = fullWidth;


### PR DESCRIPTION
`CGFloat` is a `float` on 32-bit architectures and a `double` on 64-bit architectures. This makes the use of `fabsf` inappropriate on 64-bit arm. 

I propose using the preprocessor macro `ABS` to avoid the problem altogether.

The reason for such a change is to help the use of this library on projects where strict static analysis is enforced.

A longer, more explicit architecture-dependent approach is also possible. 

```objc
#if CGFLOAT_IS_DOUBLE
    CGFloat fullWidth = fabs(finalLeftEdge - initialLeftEdge);
#else
    CGFloat fullWidth = fabsf(finalLeftEdge - initialLeftEdge);
#endif
```

This may be preferable in cases where the distinct functions are known to have some advantage. However absolute value is a simple enough function that the macro's behavior will be identical.
