### PR TITLE
viewWill/Did events may sometimes stop firing on underneath controller

### DIFF
--- a/ECSlidingViewController.podspec
+++ b/ECSlidingViewController.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = "ECSlidingViewController"
-  s.version      = "2.0.3"
+  s.version      = "2.0.4"
   s.summary      = "View controller container that presents its child view controllers in two sliding layers. Inspired by the Path 2.0 and Facebook iPhone apps."
   s.description  = "ECSlidingViewController is a view controller container that presents its child view controllers in two layers. It provides functionality for sliding the top view to reveal the views underneath it. This functionality is inspired by the Path 2.0 and Facebook iPhone apps."
   s.homepage     = "https://github.com/ECSlidingViewController/ECSlidingViewController"
   s.license      = 'MIT'
   s.author       = { "Mike Enriquez" => "mike@enriquez.me" }
-  s.source       = { :git => "https://github.com/ECSlidingViewController/ECSlidingViewController.git", :tag => "2.0.3" }
+  s.source       = { :git => "https://github.com/ECSlidingViewController/ECSlidingViewController.git", :tag => "2.0.4" }
 
   s.platform     = :ios, '7.0'
   s.requires_arc = true

--- a/ECSlidingViewController/ECSlidingInteractiveTransition.m
+++ b/ECSlidingViewController/ECSlidingInteractiveTransition.m
@@ -52,7 +52,7 @@
     UIViewController *topViewController = [transitionContext viewControllerForKey:ECTransitionContextTopViewControllerKey];
     CGFloat finalLeftEdge = CGRectGetMinX([transitionContext finalFrameForViewController:topViewController]);
     CGFloat initialLeftEdge = CGRectGetMinX([transitionContext initialFrameForViewController:topViewController]);
-    CGFloat fullWidth = fabsf(finalLeftEdge - initialLeftEdge);
+    CGFloat fullWidth = fabs(finalLeftEdge - initialLeftEdge);
     
     self.positiveLeftToRight = initialLeftEdge < finalLeftEdge;
     self.fullWidth           = fullWidth;

--- a/ECSlidingViewController/ECSlidingViewController.h
+++ b/ECSlidingViewController/ECSlidingViewController.h
@@ -59,7 +59,7 @@
  
  @param slidingViewController The sliding view controller that is being transitioned.
  @param operation The type of transition that is occuring. See `ECSlidingViewControllerOperation` for a list of possible values.
- @param topViewController
+ @param topViewController The view controller in the 'top' position
  
  @return The animator object responsible for managing the transition animations, or nil if you want to use the standard sliding view controller transitions. The object you return must conform to the `UIViewControllerAnimatedTransitioning` protocol.
  */

--- a/ECSlidingViewController/ECSlidingViewController.h
+++ b/ECSlidingViewController/ECSlidingViewController.h
@@ -284,6 +284,11 @@
 @property (nonatomic, assign, readonly) ECSlidingViewControllerTopViewPosition currentTopViewPosition;
 
 /**
+ The current operation.
+ */
+@property (nonatomic, assign, readonly) ECSlidingViewControllerOperation currentOperation;
+
+/**
  The gesture that triggers the default interactive transition for a horizontal swipe. This is typically added to the top view or one of the top view's subviews.
  */
 @property (nonatomic, strong, readonly) UIPanGestureRecognizer *panGesture;

--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -278,9 +278,11 @@
     _underLeftViewController = underLeftViewController;
     
     if (_underLeftViewController) {
-        // Ensure correct translation of autoresizingMask into constraints
+        // Ensure correct translation of autoresizingMask into Auto Layout constraints
         // (avoid "Unable to simultaneously satisfy constraints" during rotation).
+        // Also ensures width is never (temporarily) incorrect during rotation.
         _underLeftViewController.view.autoresizingMask |= UIViewAutoresizingFlexibleRightMargin;
+        _underLeftViewController.view.autoresizingMask &= ~UIViewAutoresizingFlexibleWidth;
 
         [self addChildViewController:_underLeftViewController];
         [_underLeftViewController didMoveToParentViewController:self];
@@ -299,9 +301,11 @@
     _underRightViewController = underRightViewController;
     
     if (_underRightViewController) {
-        // Ensure correct translation of autoresizingMask into constraints
+        // Ensure correct translation of autoresizingMask into Auto Layout constraints
         // (avoid "Unable to simultaneously satisfy constraints" during rotation).
+        // Also ensures width is never (temporarily) incorrect during rotation.
         _underRightViewController.view.autoresizingMask |= UIViewAutoresizingFlexibleLeftMargin;
+        _underRightViewController.view.autoresizingMask &= ~UIViewAutoresizingFlexibleWidth;
         
         [self addChildViewController:_underRightViewController];
         [_underRightViewController didMoveToParentViewController:self];

--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -28,7 +28,7 @@
 #import "ECSlidingSegue.h"
 
 @interface ECSlidingViewController()
-@property (nonatomic, assign) ECSlidingViewControllerOperation currentOperation;
+@property (nonatomic, assign, readwrite) ECSlidingViewControllerOperation currentOperation;
 @property (nonatomic, strong) ECSlidingAnimationController *defaultAnimationController;
 @property (nonatomic, strong) ECSlidingInteractiveTransition *defaultInteractiveTransition;
 @property (nonatomic, strong) id<UIViewControllerAnimatedTransitioning> currentAnimationController;

--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -646,7 +646,7 @@
     UIViewController *viewControllerWillDisappear = [self viewControllerWillDisappearForSuccessfulOperation:operation];
     
     [viewControllerWillAppear    beginAppearanceTransition:YES animated:_isAnimated];
-    [viewControllerWillDisappear beginAppearanceTransition:NO animated:_isAnimated];
+    [viewControllerWillDisappear beginAppearanceTransition:NO animated:NO];
 }
 
 - (void)endAppearanceTransitionForOperation:(ECSlidingViewControllerOperation)operation isCancelled:(BOOL)canceled {

--- a/ECSlidingViewController/ECSlidingViewController.m
+++ b/ECSlidingViewController/ECSlidingViewController.m
@@ -278,6 +278,10 @@
     _underLeftViewController = underLeftViewController;
     
     if (_underLeftViewController) {
+        // Ensure correct translation of autoresizingMask into constraints
+        // (avoid "Unable to simultaneously satisfy constraints" during rotation).
+        _underLeftViewController.view.autoresizingMask |= UIViewAutoresizingFlexibleRightMargin;
+
         [self addChildViewController:_underLeftViewController];
         [_underLeftViewController didMoveToParentViewController:self];
     }
@@ -295,6 +299,10 @@
     _underRightViewController = underRightViewController;
     
     if (_underRightViewController) {
+        // Ensure correct translation of autoresizingMask into constraints
+        // (avoid "Unable to simultaneously satisfy constraints" during rotation).
+        _underRightViewController.view.autoresizingMask |= UIViewAutoresizingFlexibleLeftMargin;
+        
         [self addChildViewController:_underRightViewController];
         [_underRightViewController didMoveToParentViewController:self];
     }


### PR DESCRIPTION
Sporadically and unpredictably, the underneath controller may stop having its viewWill/Did events being called. The fix is to pass animated=NO to the beginAppearanceTransition method of the underneath controller, only when it is disappearing. It took me 2 full days to find and fix this bug.
